### PR TITLE
Add two options

### DIFF
--- a/dist/html/credentialSelector.html
+++ b/dist/html/credentialSelector.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
     <head>
         <meta charset="UTF-8">
         <title>ChromeKeePass: Select credentials to use</title>
@@ -12,7 +12,7 @@
             <span id="title">Select credentials to use</span>
         </div>
         <div id="credentialsList">
-            <center>Loading credentials...</center>
+            <div style="text-align: center">Loading credentials...</div>
         </div>
         <div class="footer">
             <button onclick="window.close()">Cancel</button>

--- a/dist/html/options.html
+++ b/dist/html/options.html
@@ -21,6 +21,11 @@
         </label>
         <br /><br />
         <label>
+            Show dropdown when username fields is focussed on detection
+            <input id="showDropdownOnDetectionFocus" type="checkbox"/>
+        </label>
+        <br /><br />
+        <label>
             <input id="showDropdownOnClick" type="checkbox" />
             Show dropdown when username field is clicked
         </label>

--- a/dist/html/options.html
+++ b/dist/html/options.html
@@ -8,36 +8,41 @@
     <body>
         <h1>Status</h1>
         <span id="connectionStatus">Getting status...</span>
-        
+
         <h1>Options</h1>
         <label>
-            <input id="showUsernameIcon" type="checkbox" /> 
+            <input id="showUsernameIcon" type="checkbox" />
             Show ChromeKeePass icon in username field
         </label>
         <br /><br />
         <label>
-            <input id="showDropdownOnFocus" type="checkbox" /> 
+            <input id="showDropdownOnFocus" type="checkbox" />
             Show dropdown when username field gets focussed
         </label>
         <br /><br />
         <label>
-            <input id="autoFillSingleCredential" type="checkbox" /> 
+            <input id="showDropdownOnClick" type="checkbox" />
+            Show dropdown when username field is clicked
+        </label>
+        <br /><br />
+        <label>
+            <input id="autoFillSingleCredential" type="checkbox" />
             Automatically fill credentials if only a single entry is found
         </label>
         <br /><br />
         <label>
-            <input id="autoComplete" type="checkbox" /> 
+            <input id="autoComplete" type="checkbox" />
             Show matching credentials while typing in the username field
         </label>
         <br /><br />
         <label>
             KeePassHttp host:
-            <input id="keePassHost" type="text" /> 
+            <input id="keePassHost" type="text" />
         </label>
         <br /><br />
         <label>
             KeePassHttp port:
-            <input id="keePassPort" type="number" /> 
+            <input id="keePassPort" type="number" />
         </label>
         <br /><br />
         <h1>Theme</h1>

--- a/dist/html/options.html
+++ b/dist/html/options.html
@@ -40,6 +40,12 @@
             <input id="keePassPort" type="number" /> 
         </label>
         <br /><br />
+        <h1>Theme</h1>
+        <label>
+            <input id="enableDropdownFooter" type="checkbox" />
+            Enable the footer in the credential list dropdown
+        </label>
+        <br /><br />
         <h1>Shortcuts</h1>
         <div id="shortcuts"></div>
         <small>You can change shortcuts using the Extensions > Keyboard Shortcuts option in Chrome</small>

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -10,6 +10,8 @@ export interface ISettings
     showUsernameIcon: boolean;
     /** Show the dropdown when username field gets focus */
     showDropdownOnFocus: boolean;
+    /** Show the dropdown when username field has focus when it is detected */
+    showDropdownOnDetectionFocus: boolean;
     /** Show the dropdown when username field is clicked */
     showDropdownOnClick: boolean;
     /** Automatically fill credential field when there is only one credential found */
@@ -28,6 +30,7 @@ export const defaultSettings: ISettings =
 {
     showUsernameIcon: true,
     showDropdownOnFocus: true,
+    showDropdownOnDetectionFocus: true,
     showDropdownOnClick: false,
     autoFillSingleCredential: true,
     autoComplete: true,

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -1,4 +1,9 @@
 
+export interface ITheme {
+    /** Show a footer in the credential dropdown list? */
+    enableDropdownFooter: boolean;
+}
+
 export interface ISettings
 {
     /** Show the ChromeKeePass icon in the username field? */
@@ -13,6 +18,8 @@ export interface ISettings
     keePassHost: string;
     /** The port for KeePassHttp */
     keePassPort: number;
+    /** Settings determining the look of user interface elements */
+    theme: ITheme;
 }
 
 export const defaultSettings: ISettings = 
@@ -23,6 +30,9 @@ export const defaultSettings: ISettings =
     autoComplete: true,
     keePassHost: 'localhost',
     keePassPort: 19455,
+    theme: {
+        enableDropdownFooter: true,
+    }
 }
 
 /** Async method for loading settings */

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -10,6 +10,8 @@ export interface ISettings
     showUsernameIcon: boolean;
     /** Show the dropdown when username field gets focus */
     showDropdownOnFocus: boolean;
+    /** Show the dropdown when username field is clicked */
+    showDropdownOnClick: boolean;
     /** Automatically fill credential field when there is only one credential found */
     autoFillSingleCredential: boolean;
     /** Show suggestions while typing in the username field */
@@ -26,6 +28,7 @@ export const defaultSettings: ISettings =
 {
     showUsernameIcon: true,
     showDropdownOnFocus: true,
+    showDropdownOnClick: false,
     autoFillSingleCredential: true,
     autoComplete: true,
     keePassHost: 'localhost',

--- a/src/classes/FieldSet.ts
+++ b/src/classes/FieldSet.ts
@@ -50,8 +50,9 @@ export default class FieldSet
         this._controlField.on('click', this._onClick.bind(this)).on('keydown', this._onKeyPress.bind(this)).on('keyup', this._onKeyUp.bind(this));
 
         // Maybe we need to open the dropdown?
-        if(this._pageControl.settings.showDropdownOnFocus && this._controlField.is(':focus'))
+        if (this._pageControl.settings.showDropdownOnDetectionFocus && this._controlField.is(':focus')) {
             this._openDropdown(this._controlField, false);
+        }
 
         // Should we show the icon in the username field?
         if(this._pageControl.settings.showUsernameIcon)

--- a/src/classes/FieldSet.ts
+++ b/src/classes/FieldSet.ts
@@ -182,11 +182,15 @@ export default class FieldSet
 
     /**
      * Open the credentials dropdown under the `target`
-     * @param target 
+     * @param target The html element to open the target under.
+     * @param showWithOnlyOneChoice: Whether or not to show the dropdown if there is only one choice.
      */
-    private _openDropdown(target: JQuery)
+    private _openDropdown(target: JQuery, showWithOnlyOneChoice = true)
     {
         if(this._dropdown !== undefined) return; // Dropdown is already open
+        if (!showWithOnlyOneChoice && this._pageControl.credentials && this._pageControl.credentials.length === 1) {
+            return; // No need to display the dropdown menu if there is only one option
+        }
         if((new Date()).getTime() - (this._dropdownCloseTime || 0) < 1000) return; // The dropdown was closed less than a second ago, it doesn't make sense to open it again so quickly
         this._dropdownOpenTime = (new Date()).getTime();
 

--- a/src/classes/FieldSet.ts
+++ b/src/classes/FieldSet.ts
@@ -199,20 +199,26 @@ export default class FieldSet
             width: `${target.outerWidth()}px`
         });
 
-        const footerItems: (JQuery<HTMLElement>|string)[] = [
-            $('<img>').addClass(styles.logo).attr('src', chrome.extension.getURL('images/icon48.png')),
-            'ChromeKeePass',
-            $('<img>').attr('src', chrome.extension.getURL('images/gear.png')).attr('title', 'Open settings').css({cursor: 'pointer'}).click(this._openOptionsWindow.bind(this)),
-            // $('<img>').attr('src', chrome.extension.getURL('images/key.png')).attr('title', 'Generate password').css({cursor: 'pointer'}),
-        ];
-        const footer = $('<div>').addClass(styles.footer).append(...footerItems);
-
         // Generate the content
         const content = $('<div>').addClass(styles.content);
         this._generateDropdownContent(content);
+        this._dropdown.append(content);
         
-        // Add the content en footer to the dropdown and show it
-        this._dropdown.append(content).append(footer);
+        if (this._pageControl.settings.theme.enableDropdownFooter) {
+            // Create the footer and add it to the dropdown
+            const footerItems: (JQuery | string)[] = [
+                $('<img>').addClass(styles.logo).attr('src', chrome.extension.getURL('images/icon48.png')),
+                'ChromeKeePass',
+                $('<img>').attr('src', chrome.extension.getURL('images/gear.png'))
+                    .attr('title', 'Open settings').css({cursor: 'pointer'})
+                    .on('click', FieldSet._openOptionsWindow.bind(this)),
+                // $('<img>').attr('src', chrome.extension.getURL('images/key.png')).attr('title', 'Generate password').css({cursor: 'pointer'}),
+            ];
+            const footer = $('<div>').addClass(styles.footer).append(...footerItems);
+            this._dropdown.append(footer);
+        }
+
+        // Show the dropdown
         $(document.body).append(this._dropdown);
     }
 

--- a/src/classes/FieldSet.ts
+++ b/src/classes/FieldSet.ts
@@ -51,7 +51,7 @@ export default class FieldSet
 
         // Maybe we need to open the dropdown?
         if(this._pageControl.settings.showDropdownOnFocus && this._controlField.is(':focus'))
-            this._openDropdown(this._controlField);
+            this._openDropdown(this._controlField, false);
 
         // Should we show the icon in the username field?
         if(this._pageControl.settings.showUsernameIcon)
@@ -95,16 +95,16 @@ export default class FieldSet
     }
 
     /** Event when the username field is clicked */
-    private _onClick(e: JQuery.ClickEvent)
-    {
-        if(this._onIcon) // Only continue if the cursor is on the icon
-        {
-            e.preventDefault();
-
-            if(this._dropdown)
+    private _onClick(event: JQuery.ClickEvent) {
+        if (this._onIcon) { // Only continue if the cursor is on the icon
+            event.preventDefault();
+            if (this._dropdown) {
                 this.closeDropdown();
-            else
+            } else {
                 this._openDropdown(this._controlField);
+            }
+        } else if (this._pageControl.settings.showDropdownOnClick && this._dropdown === undefined) {
+            this._openDropdown(this._controlField);
         }
     }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -48,6 +48,7 @@ function fillSettings()
     loadSettings().then((settings)=>{
         $('#showUsernameIcon').prop('checked', settings.showUsernameIcon);
         $('#showDropdownOnFocus').prop('checked', settings.showDropdownOnFocus);
+        $('#showDropdownOnClick').prop('checked', settings.showDropdownOnClick);
         $('#autoFillSingleCredential').prop('checked', settings.autoFillSingleCredential);
         $('#autoComplete').prop('checked', settings.autoComplete);
         $('#keePassHost').val(settings.keePassHost);
@@ -64,6 +65,7 @@ function doSave()
     saveSettings({
         showUsernameIcon: $('#showUsernameIcon').prop('checked'),
         showDropdownOnFocus: $('#showDropdownOnFocus').prop('checked'),
+        showDropdownOnClick: $('#showDropdownOnClick').prop('checked'),
         autoFillSingleCredential: $('#autoFillSingleCredential').prop('checked'),
         autoComplete: $('#autoComplete').prop('checked'),
         keePassHost: $('#keePassHost').val() as string,

--- a/src/options.ts
+++ b/src/options.ts
@@ -48,7 +48,7 @@ function fillSettings()
     loadSettings().then((settings)=>{
         $('#showUsernameIcon').prop('checked', settings.showUsernameIcon);
         $('#showDropdownOnFocus').prop('checked', settings.showDropdownOnFocus);
-        $('#showDropdownOnPageLoadFocus').prop('checked', settings.showDropdownOnDetectionFocus);
+        $('#showDropdownOnDetectionFocus').prop('checked', settings.showDropdownOnDetectionFocus);
         $('#showDropdownOnClick').prop('checked', settings.showDropdownOnClick);
         $('#autoFillSingleCredential').prop('checked', settings.autoFillSingleCredential);
         $('#autoComplete').prop('checked', settings.autoComplete);
@@ -66,7 +66,7 @@ function doSave()
     saveSettings({
         showUsernameIcon: $('#showUsernameIcon').prop('checked'),
         showDropdownOnFocus: $('#showDropdownOnFocus').prop('checked'),
-        showDropdownOnDetectionFocus: $('#showDropdownOnPageLoadFocus').prop('checked'),
+        showDropdownOnDetectionFocus: $('#showDropdownOnDetectionFocus').prop('checked'),
         showDropdownOnClick: $('#showDropdownOnClick').prop('checked'),
         autoFillSingleCredential: $('#autoFillSingleCredential').prop('checked'),
         autoComplete: $('#autoComplete').prop('checked'),

--- a/src/options.ts
+++ b/src/options.ts
@@ -48,6 +48,7 @@ function fillSettings()
     loadSettings().then((settings)=>{
         $('#showUsernameIcon').prop('checked', settings.showUsernameIcon);
         $('#showDropdownOnFocus').prop('checked', settings.showDropdownOnFocus);
+        $('#showDropdownOnPageLoadFocus').prop('checked', settings.showDropdownOnDetectionFocus);
         $('#showDropdownOnClick').prop('checked', settings.showDropdownOnClick);
         $('#autoFillSingleCredential').prop('checked', settings.autoFillSingleCredential);
         $('#autoComplete').prop('checked', settings.autoComplete);
@@ -65,6 +66,7 @@ function doSave()
     saveSettings({
         showUsernameIcon: $('#showUsernameIcon').prop('checked'),
         showDropdownOnFocus: $('#showDropdownOnFocus').prop('checked'),
+        showDropdownOnDetectionFocus: $('#showDropdownOnPageLoadFocus').prop('checked'),
         showDropdownOnClick: $('#showDropdownOnClick').prop('checked'),
         autoFillSingleCredential: $('#autoFillSingleCredential').prop('checked'),
         autoComplete: $('#autoComplete').prop('checked'),

--- a/src/options.ts
+++ b/src/options.ts
@@ -52,6 +52,7 @@ function fillSettings()
         $('#autoComplete').prop('checked', settings.autoComplete);
         $('#keePassHost').val(settings.keePassHost);
         $('#keePassPort').val(settings.keePassPort);
+        $('#enableDropdownFooter').prop('checked', settings.theme.enableDropdownFooter);
     });
 }
 
@@ -67,6 +68,9 @@ function doSave()
         autoComplete: $('#autoComplete').prop('checked'),
         keePassHost: $('#keePassHost').val() as string,
         keePassPort: parseInt($('#keePassPort').val() as any),
+        theme: {
+            enableDropdownFooter: $('#enableDropdownFooter').prop('checked'),
+        },
     }).then(() => {
         const saveStatus = $('#saveStatus');
         saveStatus.text('Options saved');


### PR DESCRIPTION
This adds three new options:

* Allow to hide the footer in the credentials dropdown:
  ![The new option in the settings.](https://user-images.githubusercontent.com/6966049/113337299-e29ed600-9327-11eb-9e90-5b177637c8e5.png)
  I'm personally not a fan of the footer, it doesn't really serve a purpose, so I would like to be able to disable it.
  It is of course still enabled by default. I put it into a `Theme` group, because there will be other options added in future commits.
* Allow to open the credential dropdown when clicking on the input field.
  ![The new option in the settings.](https://user-images.githubusercontent.com/6966049/113337691-6c4ea380-9328-11eb-8c87-39698b1fd6b2.png)
  This makes the extension behave more like the auto-fill builtin Google Chrome. It is not enabled by default, to preserve existing configurations. Do you think it should be enabled by default?
* Allow to disable showing the dropdown menu if a input field has focus on page load, because this behavior can feel very invasive and is also not how the auto-fill builtin Google Chrome behaves, that the user will already be used to. It is enabled by default, though I would strongly recommend changing the default to not enabled. Most users will be used to the builtin auto-fill, I believe emulating its behavior in this extension will make the extension feel more familiar to users, therefore improving their experience.
  ![The option in the settings.](https://user-images.githubusercontent.com/6966049/113489230-50333980-94c3-11eb-822e-52c8293a8892.png)
  The option looks a bit weird in the settings because it doesn't fit on one line. This will change in one of the next pull requests where I restyled the settings.
