### PR TITLE
Close the credentials dropown when the input field looses focus

### DIFF
--- a/src/classes/FieldSet.ts
+++ b/src/classes/FieldSet.ts
@@ -12,10 +12,6 @@ export default class FieldSet
 {
     /** Pointer to the dropdown */
     private _dropdown?: JQuery;
-    /** Timestamp from when the dropdown is closed, to prevent is from opening again directly after closing */
-    private _dropdownCloseTime?: number;
-    /** Timestamp from when the dropdown is opened, to prevent is from closing directly after opening */
-    private _dropdownOpenTime?: number;
     /** Pointers to the credentials shown in the dropdown */
     private _credentialItems?: JQuery[];
     /** Index of the credentials selected from `_credentialItems` */
@@ -200,8 +196,6 @@ export default class FieldSet
         if (!showWithOnlyOneChoice && this._pageControl.credentials && this._pageControl.credentials.length === 1) {
             return; // No need to display the dropdown menu if there is only one option
         }
-        if((new Date()).getTime() - (this._dropdownCloseTime || 0) < 1000) return; // The dropdown was closed less than a second ago, it doesn't make sense to open it again so quickly
-        this._dropdownOpenTime = (new Date()).getTime();
 
         const targetOffset = target.offset();
 
@@ -240,14 +234,11 @@ export default class FieldSet
     {
         if(this._dropdown)
         {
-            if((new Date()).getTime() - (this._dropdownOpenTime || 0) < 500) return; // The dropdown was opened less than 0.5 seconds ago, it doesn't make sense to close it again so quickly
-
             this._dropdown.remove();
             this._credentialItems = undefined;
             this._selectedCredential = undefined;
             this._selectedCredentialIndex = undefined;
             this._dropdown = undefined;
-            this._dropdownCloseTime = (new Date()).getTime();
         }
     }
 

--- a/src/classes/FieldSet.ts
+++ b/src/classes/FieldSet.ts
@@ -46,7 +46,7 @@ export default class FieldSet
         this._controlFieldTitle = this._controlField.attr('title') || '';
         this._controlField.attr('autocomplete', 'off');
 
-        this._controlField.on('mousemove', this._onMouseMove.bind(this)).on('mouseleave', this._activateIcon.bind(this, true)).on('focus', this._onFocus.bind(this));
+        this._controlField.on('mousemove', this._onMouseMove.bind(this)).on('mouseleave', this._activateIcon.bind(this, true)).on('focusin', this._onFocus.bind(this)).on('focusout', this._onFocusLost.bind(this));
         this._controlField.on('click', this._onClick.bind(this)).on('keydown', this._onKeyPress.bind(this)).on('keyup', this._onKeyUp.bind(this));
 
         // Maybe we need to open the dropdown?
@@ -89,10 +89,18 @@ export default class FieldSet
     }
 
     /** Event when the username field gets focussed */
-    private _onFocus(_event: JQuery.FocusEvent)
-    {
-        if(this._pageControl.settings.showDropdownOnFocus) // Show the dropdown when this happens?
-            this._openDropdown(this._controlField);
+    private _onFocus(_event: JQuery.FocusInEvent) {
+        // Show the dropdown on focus when enabled and whe either have more than one credential or no credentials.
+        if (this._pageControl.settings.showDropdownOnFocus) {
+            this._openDropdown(this._controlField, false);
+        }
+    }
+
+    /** Event when the username field loses focussed */
+    private _onFocusLost(event: JQuery.FocusOutEvent) {
+        if (this._dropdown && !this._dropdown.is(':focus')) {
+            this.closeDropdown();
+        }
     }
 
     /** Event when the username field is clicked */

--- a/src/classes/FieldSet.ts
+++ b/src/classes/FieldSet.ts
@@ -94,9 +94,11 @@ export default class FieldSet
 
     /** Event when the username field loses focussed */
     private _onFocusLost(_event: JQuery.FocusOutEvent) {
-        if (this._dropdown && !this._dropdown.is(':focus')) {
-            this.closeDropdown();
-        }
+        setTimeout(() => {
+            if (this._dropdown && !this._dropdown.is(':focus')) {
+                this.closeDropdown();
+            }
+        }, 100);
     }
 
     /** Event when the username field is clicked */

--- a/src/classes/FieldSet.ts
+++ b/src/classes/FieldSet.ts
@@ -25,7 +25,7 @@ export default class FieldSet
     /** Variable holding all icon styles (to easily remove all the styles at once) */
     private static allIconStyles = `${styles.green} ${styles.orange} ${styles.red}`;
     /** This is the field where gonna use ChromeKeePass's controls */
-    private readonly _controlField: JQuery = $('<input>'); // Input a dummy `<div>`, because TypeScript will complain the variable could be undefined
+    private readonly _controlField: JQuery;
     /** Used to remember the original title attribute from the username field (because it changes when the cursor hovers the ChromeKeePass icon) */
     private readonly _controlFieldTitle: string = '';
 
@@ -93,7 +93,7 @@ export default class FieldSet
     }
 
     /** Event when the username field loses focussed */
-    private _onFocusLost(event: JQuery.FocusOutEvent) {
+    private _onFocusLost(_event: JQuery.FocusOutEvent) {
         if (this._dropdown && !this._dropdown.is(':focus')) {
             this.closeDropdown();
         }
@@ -213,11 +213,13 @@ export default class FieldSet
         
         if (this._pageControl.settings.theme.enableDropdownFooter) {
             // Create the footer and add it to the dropdown
+            // noinspection HtmlRequiredAltAttribute,RequiredAttributes
             const footerItems: (JQuery | string)[] = [
-                $('<img>').addClass(styles.logo).attr('src', chrome.extension.getURL('images/icon48.png')),
+                $('<img>').addClass(styles.logo).attr('src', chrome.extension.getURL('images/icon48.png'))
+                    .attr('alt', ''),
                 'ChromeKeePass',
                 $('<img>').attr('src', chrome.extension.getURL('images/gear.png'))
-                    .attr('title', 'Open settings').css({cursor: 'pointer'})
+                    .attr('alt', 'Open Settings').attr('title', 'Open settings').css({cursor: 'pointer'})
                     .on('click', FieldSet._openOptionsWindow.bind(this)),
                 // $('<img>').attr('src', chrome.extension.getURL('images/key.png')).attr('title', 'Generate password').css({cursor: 'pointer'}),
             ];

--- a/src/classes/PageControl.ts
+++ b/src/classes/PageControl.ts
@@ -7,6 +7,7 @@ import Client from '../classes/BackgroundClient';
 
 export default class PageControl
 {
+    private _installedEscapeHandler = false;
     private _fieldSets: FieldSet[] = [];
     private _foundCredentials?: IMessage.Credential[];
     private _settings: ISettings = defaultSettings;
@@ -68,8 +69,10 @@ export default class PageControl
 
     private _attachEscapeEvent()
     {
-        if(!this._fieldSets || this._fieldSets.length === 0) return; // We're not going to listen to key presses if we don't need them
-
+        if(this._installedEscapeHandler || !this._fieldSets || this._fieldSets.length === 0) {
+            return; // We're not going to listen to key presses if we don't need them
+        }
+        this._installedEscapeHandler = true;
         $(document).on('keyup', (e: JQuery.KeyUpEvent<Document>)=>{
             if(e.key == 'Escape')
             {


### PR DESCRIPTION
_This pull requests depends on and includes commits in #38, merge that pull request before taking a look at this one._

Another change that makes the extension behave much more like the builtin auto-fill in Chrome. When the input field looses focus and the dropdown didn't gain focus, the dropdown is automatically closed. This prevents the need to press escape to close those stuck dropdown that pop up tell me that I don't have an account for site `xyz` every time I visit the site.

The timed restriction on when to open the credential dropdown is no longer needed and is removed by this pull request. I assume it was added to prevent accidental reopening of the dropdown when it is closed via the icon in the input field, but this is no longer necessary. Also, it made the dropdown feel very unresponsive in certain situations. As a side note, the `setTimeout` workaround in `_onFocusLost` is not ideal, I found a much better solution later. Unfortunately I can't include it into this bull request, because it is build on top of other unrelated changes.

This also fixes and issue where it was possible for us to register the global escape handler more than once.
Unfortunately `PageControl.ts` had the wrong line endings, so the diff doesn't really show the important changes again.
<details>
<summary>These are the actual changes in that file.</summary>

![Changes in PageControl.ts](https://user-images.githubusercontent.com/6966049/113428074-6b744b00-93d6-11eb-9a19-0e3c3c5933cb.png)

</details>