### PR TITLE
Add an option to re-detect password fields when the website changes

### DIFF
--- a/dist/html/options.html
+++ b/dist/html/options.html
@@ -37,7 +37,7 @@
         <br /><br />
         <label>
             <input id="searchForInputsOnUpdate" type="checkbox" />
-            Re-detect username and password fields when the website changes
+            Re-detect username and password fields when the website updates
         </label>
         <br /><br />
         <label>

--- a/dist/html/options.html
+++ b/dist/html/options.html
@@ -36,6 +36,11 @@
         </label>
         <br /><br />
         <label>
+            <input id="searchForInputsOnUpdate" type="checkbox" />
+            Re-detect username and password fields when the website changes
+        </label>
+        <br /><br />
+        <label>
             <input id="autoComplete" type="checkbox" />
             Show matching credentials while typing in the username field
         </label>

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -38,7 +38,7 @@ export const defaultSettings: ISettings =
     autoComplete: true,
     keePassHost: 'localhost',
     keePassPort: 19455,
-    searchForInputsOnUpdate: false,
+    searchForInputsOnUpdate: true,
     theme: {
         enableDropdownFooter: true,
     }

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -18,10 +18,12 @@ export interface ISettings
     autoFillSingleCredential: boolean;
     /** Show suggestions while typing in the username field */
     autoComplete: boolean;
-    /** The host for KeePassHttp  */
+    /** The host for KeePassHttp */
     keePassHost: string;
     /** The port for KeePassHttp */
     keePassPort: number;
+    /** Listen for changes in the html document and search for new input fields */
+    searchForInputsOnUpdate: boolean;
     /** Settings determining the look of user interface elements */
     theme: ITheme;
 }
@@ -36,6 +38,7 @@ export const defaultSettings: ISettings =
     autoComplete: true,
     keePassHost: 'localhost',
     keePassPort: 19455,
+    searchForInputsOnUpdate: false,
     theme: {
         enableDropdownFooter: true,
     }

--- a/src/classes/PageControl.ts
+++ b/src/classes/PageControl.ts
@@ -33,31 +33,10 @@ export default class PageControl
         if(passwordFields.length) // Found some password fields?
         {
             passwordFields.each((passwordIndex, passwordField)=>{ // Loop through password fields
-                let prevField: JQuery;
-
-                $('input').each((inputIndex, input)=>{ // Loop through input fields to find the field before our password field
-                    const inputType = $(input).attr('type') || 'text'; // Get input type, if none default to "text"
-                    if(inputType != 'password') // We didn't reach our password field?
-                    {
-                        if($(input).is(':visible') && (inputType === 'text' || inputType === 'email' || inputType === 'tel')) // Is this a possible username field?
-                            prevField = $(input);
-                    }
-                    else if($(input).is($(passwordField))) // Found our password field?
-                    {
-                        if(prevField) // Is there a previous field? Than this should be our username field
-                        {
-                            fieldSets.push(new FieldSet(this, $(passwordField), prevField));
-                            return; // Break the each() loop
-                        }
-                        else if($(input).is(':visible')) // We didn't find the username field. Check if it's actually visible
-                        {
-                            fieldSets.push(new FieldSet(this, $(passwordField)));
-                            return; // Break the each() loop
-                        }
-                        else // We didn't find a visible username of password field
-                            return;
-                    }
-                });
+                let fieldSet = this._createFieldSet(passwordField);
+                if (fieldSet !== undefined) {
+                    fieldSets.push(fieldSet);
+                }
             });
         }
 
@@ -65,6 +44,46 @@ export default class PageControl
         this._fieldSets = fieldSets;
         this._findCredentials();
         this._attachEscapeEvent();
+    }
+
+    /**
+     * Try to detect new credentials fields
+     * @param passwordFields A list of changed or added password fields.
+     */
+    public detectNewFields(passwordFields: JQuery) {
+        passwordFields.each((passwordIndex, passwordField) => { // Loop through password fields
+            if (!this._fieldSets.some((fieldSet) => fieldSet.passwordField.index() !== passwordIndex)) {
+                let fieldSet = this._createFieldSet(passwordField);
+                if (fieldSet !== undefined) {
+                    this._fieldSets.push(fieldSet);
+                }
+            }
+        });
+        this._findCredentials();
+        this._attachEscapeEvent();
+    }
+
+    private _createFieldSet(passwordField: HTMLElement): FieldSet | undefined {
+        let prevField: JQuery;
+        let fieldSet: FieldSet | undefined = undefined;
+        $('input').each((inputIndex, input) => { // Loop through input fields to find the field before our password field
+            const inputType = $(input).attr('type') || 'text'; // Get input type, if none default to "text"
+            if (inputType != 'password') { // We didn't reach our password field?
+                if ($(input).is(':visible') &&
+                    (inputType === 'text' || inputType === 'email' || inputType === 'tel')) {
+                    prevField = $(input); // Is this a possible username field?
+                }
+            } else if ($(input).is($(passwordField))) { // Found our password field?
+                if (prevField) { // Is there a previous field? Than this should be our username field
+                    fieldSet = new FieldSet(this, $(passwordField), prevField);
+                } else if ($(input).is(':visible')) {
+                    // We didn't find the username field. Check if it's actually visible
+                    fieldSet = new FieldSet(this, $(passwordField));
+                } // Else we didn't find a visible username of password field
+                return false; // Break the each() loop
+            }
+        });
+        return fieldSet;
     }
 
     private _attachEscapeEvent()

--- a/src/content_script.ts
+++ b/src/content_script.ts
@@ -5,4 +5,20 @@ const pageControl = new PageControl();
 
 $(()=>{
     pageControl.detectFields();
+    if (pageControl.settings.searchForInputsOnUpdate) {
+        const observer = new MutationObserver(function (mutations) {
+            mutations.forEach(function (mutation) {
+                for (let node of mutation.addedNodes) {
+                    let passwordFields = $(node).find('input[type="password"]');
+                    if (passwordFields.length) {
+                        setTimeout(() => pageControl.detectNewFields(passwordFields), 100);
+                    }
+                }
+            });
+        });
+        observer.observe(document.body, {
+            childList: true,
+            subtree: true,
+        });
+    }
 });

--- a/src/options.ts
+++ b/src/options.ts
@@ -51,6 +51,7 @@ function fillSettings()
         $('#showDropdownOnDetectionFocus').prop('checked', settings.showDropdownOnDetectionFocus);
         $('#showDropdownOnClick').prop('checked', settings.showDropdownOnClick);
         $('#autoFillSingleCredential').prop('checked', settings.autoFillSingleCredential);
+        $('#searchForInputsOnUpdate').prop('checked', settings.searchForInputsOnUpdate);
         $('#autoComplete').prop('checked', settings.autoComplete);
         $('#keePassHost').val(settings.keePassHost);
         $('#keePassPort').val(settings.keePassPort);
@@ -69,6 +70,7 @@ function doSave()
         showDropdownOnDetectionFocus: $('#showDropdownOnDetectionFocus').prop('checked'),
         showDropdownOnClick: $('#showDropdownOnClick').prop('checked'),
         autoFillSingleCredential: $('#autoFillSingleCredential').prop('checked'),
+        searchForInputsOnUpdate: $('#searchForInputsOnUpdate').prop('checked'),
         autoComplete: $('#autoComplete').prop('checked'),
         keePassHost: $('#keePassHost').val() as string,
         keePassPort: parseInt($('#keePassPort').val() as any),


### PR DESCRIPTION
This adds an option to trigger a re-detect of input fields when the website changes (e.g. adds new `html` elements).
![The new setting (Re-detect username and password fields when the website changes)](https://user-images.githubusercontent.com/6966049/113761206-7c46f880-9717-11eb-86fe-4846183a3b5c.png)
The setting is disabled by default, because for a websites which do a lot of changes all the time, this could potentially be CPU intensive, though I have it enabled and have not yet been able to observe any noticeable CPU load.

This allows the auto detection of the login form input fields on websites like [VirusTotal](https://www.virustotal.com/gui/sign-in), which add the login form to the website after the initial page is loaded.