### PR TITLE
Improve the style of the settings UI

### DIFF
--- a/dist/css/options.css
+++ b/dist/css/options.css
@@ -55,6 +55,21 @@ body {
     margin-left: 10px;
 }
 
+#openShortcuts {
+    width: 36px;
+    height: 36px;
+    background: transparent;
+    padding: 8px;
+}
+
+#openShortcuts svg {
+    fill: #5f6368;
+    pointer-events: none;
+    display: block;
+    width: 100%;
+    height: 100%;
+}
+
 .separator {
     background: rgba(0, 0, 0, 0.06);
     height: 1px;
@@ -68,7 +83,7 @@ h2 {
     margin: 21px 0 12px 0;
 }
 
-label {
+label, .option-element {
     display: flex;
     justify-content: space-between;
     align-items: center;

--- a/dist/css/options.css
+++ b/dist/css/options.css
@@ -36,12 +36,26 @@ body {
     border-top: solid rgba(0,0,0,0.2);
     border-width: 1px;
     background: white;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+#save-footer div {
+    display: flex;
+}
+
+#cancel {
+    margin-right: 8px;
+    color: var(--accent-color);
+    background: white;
+    border: 1px solid #dadce0;
 }
 
 .group-container {
     background: white;
     box-shadow: 0 2px 2px 0 rgba(0,0,0,0.2);
-    transition: box-shadow 0.28s cubic-bezier(0.4, 0, 0.2, 1);;
+    transition: box-shadow 0.28s cubic-bezier(0.4, 0, 0.2, 1);
     border-radius: 4px;
     margin: 2px;
     padding: 10px;

--- a/dist/css/options.css
+++ b/dist/css/options.css
@@ -183,18 +183,18 @@ input[type=text]:focus, input[type=number]:focus {
 }
 
 #option-container::-webkit-scrollbar {
-    height: 5px;
-    width: 5px;
+    height: 6px;
+    width: 6px;
 }
 
 /* Track */
 #option-container::-webkit-scrollbar-track {
     background: #f1f1f1;
-    border-radius: 5px;
+    border-radius: 3px;
 }
 
 /* Handle */
 #option-container::-webkit-scrollbar-thumb {
     background: var(--accent-color);
-    border-radius: 5px;
+    border-radius: 3px;
 }

--- a/dist/css/options.css
+++ b/dist/css/options.css
@@ -87,6 +87,7 @@ label, .option-element {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 10px;
 }
 
 button {

--- a/dist/css/options.css
+++ b/dist/css/options.css
@@ -1,0 +1,170 @@
+:root {
+    --accent-color: #1a73e8;
+}
+
+body {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    margin: 0;
+    min-height: 800px;
+    min-width: 512px;
+}
+
+#main-container {
+    display: flex;
+    flex-direction: column;
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    background: #f8f9fa
+}
+
+#option-container {
+    flex-grow: 1;
+    overflow-y: auto;
+    margin: 0 0 0 10px;
+    padding-right: 10px;
+    padding-bottom: 5px;
+}
+
+#save-footer {
+    padding: 10px 10px 10px 10px;
+    border-radius: 4px;
+    border-top: solid rgba(0,0,0,0.2);
+    border-width: 1px;
+    background: white;
+}
+
+.group-container {
+    background: white;
+    box-shadow: 0 2px 2px 0 rgba(0,0,0,0.2);
+    transition: box-shadow 0.28s cubic-bezier(0.4, 0, 0.2, 1);;
+    border-radius: 4px;
+    margin: 2px;
+    padding: 10px;
+}
+
+#keePassPort {
+    width: 5em;
+}
+
+#saveStatus {
+    margin-left: 10px;
+}
+
+.separator {
+    background: rgba(0, 0, 0, 0.06);
+    height: 1px;
+    margin: 10px -10px;
+}
+
+h2 {
+    color: rgb(32 33 36);
+    font-weight: 400;
+    font-size: 108%;
+    margin: 21px 0 12px 0;
+}
+
+label {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+button {
+    background-color: var(--accent-color);
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-weight: 500;
+    padding: 8px 16px;
+    outline-width: 0;
+    user-select: none;
+}
+
+button:hover {
+    border-color: #d2e3fc;
+    background-color: #1a73e8e6;
+}
+
+input[type=checkbox] {
+    visibility: hidden;
+    width: 34px;
+    height: 16px;
+    position: relative;
+    cursor: pointer;
+}
+
+input[type=checkbox]:before {
+    visibility: visible;
+    content: '';
+    display: inline-block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 10;
+    border-radius: 8px;
+    border: 8px solid white;
+    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, .4);
+    transition: left linear 80ms, border-color linear 80ms;
+}
+
+input[type=checkbox]:after {
+    visibility: visible;
+    content: '';
+    display: inline-block;
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 18px;
+    border-radius: 6px;
+    border: 6px solid #bdc1c6;
+    transition: border-color linear 80ms;
+}
+
+input[type=checkbox]:checked:before {
+    left: 18px;
+    border-color: var(--accent-color);
+}
+
+input[type=checkbox]:checked:after {
+    border-color: rgb(141 185 244);
+}
+
+input[type=text], input[type=number] {
+    margin: 0 5px;
+    outline: none;
+    padding: 6px 8px 4px 8px;
+    background: #f1f3f4;
+    border: none;
+    border-bottom: 2px solid transparent;
+    border-radius: 4px 4px 0 0;
+    caret-color: var(--accent-color);
+}
+
+input[type=text]:focus, input[type=number]:focus {
+    border: none;
+    border-bottom: 2px solid var(--accent-color);
+    caret-color: var(--accent-color);
+}
+
+#option-container::-webkit-scrollbar {
+    height: 5px;
+    width: 5px;
+}
+
+/* Track */
+#option-container::-webkit-scrollbar-track {
+    background: #f1f1f1;
+    border-radius: 5px;
+}
+
+/* Handle */
+#option-container::-webkit-scrollbar-thumb {
+    background: var(--accent-color);
+    border-radius: 5px;
+}

--- a/dist/css/popup.css
+++ b/dist/css/popup.css
@@ -7,7 +7,7 @@
 body {
     min-width: 225px;
     font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
-    margin: 0px;
+    margin: 0;
     background-image: linear-gradient(to right, var(--lightPurple), var(--darkPurple));
 }
 
@@ -18,7 +18,7 @@ body {
     padding: 3px;
     font-weight: bold;
     color: var(--lightPurple);
-    text-shadow: 0px 0px 2px black;
+    text-shadow: 0 0 2px black;
     box-sizing: border-box;
     white-space: nowrap;
     overflow: hidden;
@@ -39,9 +39,9 @@ body {
 #credentialsList {
     background-color: #fff;
     position: absolute;
-    left: 0px;
+    left: 0;
     top: 30px;
-    right: 0px;
+    right: 0;
     bottom: 30px;
     overflow: hidden;
     overflow-y: auto;
@@ -62,8 +62,8 @@ body {
 .footer {
     position: absolute;
     padding: 5px;
-    left: 0px;
-    right: 0px;
-    bottom: 0px;
+    left: 0;
+    right: 0;
+    bottom: 0;
     text-align: right;
 }

--- a/dist/html/options.html
+++ b/dist/html/options.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>ChromeKeePass</title>
-    <link rel="stylesheet" type="text/css" href="../css/options.css" />
+    <link rel="stylesheet" type="text/css" href="../css/options.css"/>
     <script type="text/javascript" src="../js/options.js"></script>
 </head>
 <body>
@@ -11,14 +11,15 @@
     <div id="option-container">
         <h2 style="margin-top: 10px">Connection</h2>
         <div class="group-container">
-            <label class="option-element">
+            <label>
                 Status <span id="connectionStatus">Getting status...</span>
             </label>
             <div class="separator"></div>
             <label>
                 KeePassHttp address
-                <span class="option-element">
-                    <input id="keePassHost" type="text" placeholder="host"/>:<input id="keePassPort" type="number" placeholder="port"/>
+                <span>
+                    <input id="keePassHost" type="text" placeholder="host"/>:<input
+                        id="keePassPort" type="number" placeholder="port"/>
                 </span>
             </label>
         </div>
@@ -69,7 +70,18 @@
         <h2>Shortcuts</h2>
         <div class="group-container">
             <div id="shortcuts"></div>
-            <small>You can change shortcuts using the Extensions > Keyboard Shortcuts option in Chrome</small>
+            <div class="option-element">
+                <small>You can change shortcuts using the Extensions > Keyboard Shortcuts option in Chrome</small>
+                <button id="openShortcuts" title="Open the shortcut manager">
+                    <svg viewBox="0 0 24 24" preserveAspectRatio="xMidYMid meet" focusable="false">
+                        <g>
+                            <path d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14
+                            3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z">
+                            </path>
+                        </g>
+                    </svg>
+                </button>
+            </div>
         </div>
     </div>
     <div id="save-footer">

--- a/dist/html/options.html
+++ b/dist/html/options.html
@@ -1,71 +1,81 @@
 <!doctype html>
 <html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <title>ChromeKeePass</title>
-        <script type="text/javascript" src="../js/options.js"></script>
-    </head>
-    <body>
-        <h1>Status</h1>
-        <span id="connectionStatus">Getting status...</span>
-
-        <h1>Options</h1>
-        <label>
-            <input id="showUsernameIcon" type="checkbox" />
-            Show ChromeKeePass icon in username field
-        </label>
-        <br /><br />
-        <label>
-            <input id="showDropdownOnFocus" type="checkbox" />
-            Show dropdown when username field gets focussed
-        </label>
-        <br /><br />
-        <label>
-            Show dropdown when username fields is focussed on detection
-            <input id="showDropdownOnDetectionFocus" type="checkbox"/>
-        </label>
-        <br /><br />
-        <label>
-            <input id="showDropdownOnClick" type="checkbox" />
-            Show dropdown when username field is clicked
-        </label>
-        <br /><br />
-        <label>
-            <input id="autoFillSingleCredential" type="checkbox" />
-            Automatically fill credentials if only a single entry is found
-        </label>
-        <br /><br />
-        <label>
-            <input id="searchForInputsOnUpdate" type="checkbox" />
-            Re-detect username and password fields when the website updates
-        </label>
-        <br /><br />
-        <label>
-            <input id="autoComplete" type="checkbox" />
-            Show matching credentials while typing in the username field
-        </label>
-        <br /><br />
-        <label>
-            KeePassHttp host:
-            <input id="keePassHost" type="text" />
-        </label>
-        <br /><br />
-        <label>
-            KeePassHttp port:
-            <input id="keePassPort" type="number" />
-        </label>
-        <br /><br />
-        <h1>Theme</h1>
-        <label>
-            <input id="enableDropdownFooter" type="checkbox" />
-            Enable the footer in the credential list dropdown
-        </label>
-        <br /><br />
-        <h1>Shortcuts</h1>
-        <div id="shortcuts"></div>
-        <small>You can change shortcuts using the Extensions > Keyboard Shortcuts option in Chrome</small>
-
-        <br /><br />
-        <button id="save">Save</button> <span id="saveStatus"></span>
-    </body>
+<head>
+    <meta charset="UTF-8">
+    <title>ChromeKeePass</title>
+    <link rel="stylesheet" type="text/css" href="../css/options.css" />
+    <script type="text/javascript" src="../js/options.js"></script>
+</head>
+<body>
+<div id="main-container">
+    <div id="option-container">
+        <h2 style="margin-top: 10px">Connection</h2>
+        <div class="group-container">
+            <label class="option-element">
+                Status <span id="connectionStatus">Getting status...</span>
+            </label>
+            <div class="separator"></div>
+            <label>
+                KeePassHttp address
+                <span class="option-element">
+                    <input id="keePassHost" type="text" placeholder="host"/>:<input id="keePassPort" type="number" placeholder="port"/>
+                </span>
+            </label>
+        </div>
+        <h2>Options</h2>
+        <div class="group-container">
+            <label>
+                Show ChromeKeePass icon in username fields
+                <input id="showUsernameIcon" type="checkbox"/>
+            </label>
+            <div class="separator"></div>
+            <label>
+                Show dropdown when username fields get focussed
+                <input id="showDropdownOnFocus" type="checkbox"/>
+            </label>
+            <div class="separator"></div>
+            <label>
+                Show dropdown when username fields is focussed on detection
+                <input id="showDropdownOnDetectionFocus" type="checkbox"/>
+            </label>
+            <div class="separator"></div>
+            <label>
+                Show dropdown when username fields are clicked
+                <input id="showDropdownOnClick" type="checkbox"/>
+            </label>
+            <div class="separator"></div>
+            <label>
+                Automatically fill credentials if only a single entry is found
+                <input id="autoFillSingleCredential" type="checkbox"/>
+            </label>
+            <div class="separator"></div>
+            <label>
+                Re-detect password fields when the website updates
+                <input id="searchForInputsOnUpdate" type="checkbox"/>
+            </label>
+            <div class="separator"></div>
+            <label>
+                Show matching credentials while typing in the username field
+                <input id="autoComplete" type="checkbox"/>
+            </label>
+        </div>
+        <h2>Theme</h2>
+        <div class="group-container">
+            <label>
+                Enable the footer in the credential list dropdown
+                <input id="enableDropdownFooter" type="checkbox"/>
+            </label>
+        </div>
+        <h2>Shortcuts</h2>
+        <div class="group-container">
+            <div id="shortcuts"></div>
+            <small>You can change shortcuts using the Extensions > Keyboard Shortcuts option in Chrome</small>
+        </div>
+    </div>
+    <div id="save-footer">
+        <button id="save">Save</button>
+        <span id="saveStatus"></span>
+    </div>
+</div>
+</body>
 </html>

--- a/dist/html/options.html
+++ b/dist/html/options.html
@@ -17,8 +17,8 @@
             <div class="separator"></div>
             <label>
                 KeePassHttp address
-                <span>
-                    <input id="keePassHost" type="text" placeholder="host"/>:<input
+                <span style="display: flex; align-items: baseline">
+                    <input style="width: 100%" id="keePassHost" type="text" placeholder="host"/>:<input
                         id="keePassPort" type="number" placeholder="port"/>
                 </span>
             </label>

--- a/dist/html/options.html
+++ b/dist/html/options.html
@@ -85,8 +85,11 @@
         </div>
     </div>
     <div id="save-footer">
-        <button id="save">Save</button>
         <span id="saveStatus"></span>
+        <div>
+            <button id="cancel">Cancel</button>
+            <button id="save">Save</button>
+        </div>
     </div>
 </div>
 </body>

--- a/dist/html/options.html
+++ b/dist/html/options.html
@@ -71,7 +71,7 @@
         <div class="group-container">
             <div id="shortcuts"></div>
             <div class="option-element">
-                <small>You can change shortcuts using the Extensions > Keyboard Shortcuts option in Chrome</small>
+                <small>You can change shortcuts using the Extensions > Keyboard Shortcuts options</small>
                 <button id="openShortcuts" title="Open the shortcut manager">
                     <svg viewBox="0 0 24 24" preserveAspectRatio="xMidYMid meet" focusable="false">
                         <g>

--- a/dist/html/popup.html
+++ b/dist/html/popup.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
     <head>
         <meta charset="UTF-8">
         <title>ChromeKeePass</title>
@@ -8,9 +8,9 @@
     </head>
     <body>
         <div class="banner">
-            <img class="logo" src="../images/icon48.png" />
+            <img class="logo" src="../images/icon48.png" alt="ChromeKeePass Logo"/>
             <span id="connectionStatus">Getting status...</span>
-            <img id="optionsIcon" title="Open settings" src="../images/gear.png" />
+            <img id="optionsIcon" title="Open settings" src="../images/gear.png" alt="Open Settings"/>
         </div>
     </body>
 </html>

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -36,8 +36,7 @@
     },
 
     "options_ui": {
-        "page": "html/options.html",
-        "chrome_style": true
+        "page": "html/options.html"
     },
 
     "icons": {

--- a/src/options.ts
+++ b/src/options.ts
@@ -12,7 +12,9 @@ $(()=>{
             $('#connectionStatus').text(`Connected as '${association.Id}'`);
         else
         {
-            const associateButton = $('<button>').text('Connect').on('click', associate);
+            const associateButton = $('<button>').text('Connect').on('click', associate).css({
+                'margin-left': '10px'
+            });
             $('#connectionStatus').text('Not connected ').append(associateButton);
         }
     }).catch((error)=>{

--- a/src/options.ts
+++ b/src/options.ts
@@ -23,7 +23,10 @@ $(()=>{
     });
 
     $('#save').on('click', doSave);
-    $('#cancel').on('click', closeOptionDialog);
+    if (navigator.userAgent.indexOf('Edg/') !== -1) // Edge doesn't support closing
+        $('#cancel').remove();
+    else
+        $('#cancel').on('click', closeOptionDialog);
     $('#openShortcuts').on('click', openShortcuts);
 });
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -21,6 +21,7 @@ $(()=>{
     });
 
     $('#save').on('click', doSave);
+    $('#openShortcuts').on('click', openShortcuts);
 });
 
 function associate()
@@ -82,6 +83,15 @@ function doSave()
         saveStatus.text('Options saved');
         setTimeout(() => saveStatus.text(''), 1500);
     });
+}
+
+/**
+ * Open the Chrome shortcut manager in a new tab.
+ */
+function openShortcuts() {
+    chrome.tabs.create({
+        url: 'chrome://extensions/shortcuts'
+    })
 }
 
 /**

--- a/src/options.ts
+++ b/src/options.ts
@@ -93,7 +93,8 @@ async function getExtensionCommands()
     $('#shortcuts').empty();
 
     commands.forEach((command)=>{
-        if(command.description)
-            $('#shortcuts').append($('<div>').text(`${command.description}: ${command.shortcut}`));
+        if(command.description) {
+            $('#shortcuts').append($('<div>').text(`${command.description}: ${command.shortcut || '<Unassigned>'}`));
+        }
     });
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -21,6 +21,7 @@ $(()=>{
     });
 
     $('#save').on('click', doSave);
+    $('#cancel').on('click', closeOptionDialog);
     $('#openShortcuts').on('click', openShortcuts);
 });
 
@@ -83,6 +84,13 @@ function doSave()
         saveStatus.text('Options saved');
         setTimeout(() => saveStatus.text(''), 1500);
     });
+}
+
+/**
+ * Close the options dialog.
+ */
+function closeOptionDialog() {
+    window.close();
 }
 
 /**


### PR DESCRIPTION
_This pull request includes the commit from #41, because it adds a setting. Review that one before reviewing this._

This pull request changes the style of the settings dialog to look more like the Google Chrome settings, to give the user a more consistent look and feel.

<details>
<summary>Comparison of the settings dialog before and after.</summary>

| Before | After |
| ------- | ------  |
| ![Old Settings - Upper part](https://user-images.githubusercontent.com/6966049/113762258-b2d14300-9718-11eb-9a44-92462c2a5e78.png) ![Old Settings - Lower part](https://user-images.githubusercontent.com/6966049/113762661-1bb8bb00-9719-11eb-90b3-c6907eec3d10.png) | ![New Settings - Upper part](https://user-images.githubusercontent.com/6966049/113762362-cbd9f400-9718-11eb-8aed-5dc4af297191.png) ![New Settings - Lower part](https://user-images.githubusercontent.com/6966049/113762457-e2804b00-9718-11eb-8945-b455afad6d18.png) |
</details>

A `Cancel` button is added which allows to close the dialog without saving any changes. The `x` on the top right does the same thing, but the `Cancel` button is commonly used in dialogues in the Chrome settings.

Additionally, in the shortcuts section a link to the Chromes shortcut manager is added for the users convenience. An unassigned shortcut is now marked as `<Unassigned>` in the list.