### PR TITLE
Add more theming options for the credentials dropdown

### DIFF
--- a/dist/css/options.css
+++ b/dist/css/options.css
@@ -182,6 +182,11 @@ input[type=text]:focus, input[type=number]:focus {
     caret-color: var(--accent-color);
 }
 
+input[type=color] {
+    border: 0;
+    background: transparent;
+}
+
 #option-container::-webkit-scrollbar {
     height: 6px;
     width: 6px;

--- a/dist/css/options.css
+++ b/dist/css/options.css
@@ -1,5 +1,6 @@
 :root {
-    --accent-color: #1a73e8;
+    --accent-color-rgb: 26, 115, 232;
+    --accent-color: rgb(var(--accent-color-rgb));
 }
 
 body {
@@ -33,7 +34,7 @@ body {
 #save-footer {
     padding: 10px 10px 10px 10px;
     border-radius: 4px;
-    border-top: solid rgba(0,0,0,0.2);
+    border-top: solid rgba(0, 0, 0, 0.2);
     border-width: 1px;
     background: white;
     display: flex;
@@ -54,7 +55,7 @@ body {
 
 .group-container {
     background: white;
-    box-shadow: 0 2px 2px 0 rgba(0,0,0,0.2);
+    box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
     transition: box-shadow 0.28s cubic-bezier(0.4, 0, 0.2, 1);
     border-radius: 4px;
     margin: 2px;
@@ -118,7 +119,7 @@ button {
 
 button:hover {
     border-color: #d2e3fc;
-    background-color: #1a73e8e6;
+    background-color: rgba(var(--accent-color-rgb), 0.9);
 }
 
 input[type=checkbox] {
@@ -185,6 +186,91 @@ input[type=text]:focus, input[type=number]:focus {
 input[type=color] {
     border: 0;
     background: transparent;
+}
+
+.range-input {
+    display: flex;
+    align-items: stretch;
+    flex-direction: column;
+    min-width: 200px;
+}
+
+.range-input .labels {
+    user-select: none;
+    margin: -4px 16px 0 16px;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+}
+
+.range-input .labels span {
+    font-size: 12px;
+}
+
+.range-input input[type=range] {
+    --percent: 0%;
+    -webkit-appearance: none;
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+    cursor: default;
+    height: 32px;
+    outline: none;
+    padding: 0 16px;
+    margin: 0;
+    user-select: none;
+    visibility: hidden;
+}
+
+.range-input input[type=range]:focus {
+    outline: none;
+}
+
+.range-input input[type=range]::-webkit-slider-container {
+    visibility: visible;
+    transition: 0.3s;
+    border-top-color: rgba(var(--accent-color-rgb), .24);
+    margin-top: 16px;
+    border-top-style: solid;
+    border-top-width: 2px;
+}
+
+.range-input input[type=range]::-webkit-slider-runnable-track {
+    visibility: visible;
+    transition: 0.3s;
+    border: none;
+    margin-top: -16px;
+    height: 2px;
+    background: -webkit-linear-gradient(left, var(--accent-color) var(--percent), transparent var(--percent));
+}
+
+.range-input input[type=range]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    visibility: visible;
+    background-color: var(--accent-color);
+    border-radius: 50%;
+    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, .4);
+    height: 10px;
+    width: 10px;
+    outline: none;
+    margin-top: -4px;
+}
+
+.range-input .value-bubble-container {
+    position: relative;
+    width: 0;
+    height: 0
+}
+
+.range-input .value-bubble {
+    visibility: hidden;
+    background: var(--accent-color);
+    border-radius: 0.75em;
+    bottom: -3px;
+    width: fit-content;
+    color: white;
+    font-size: 12px;
+    padding: 0 0.67em;
+    transition: opacity 80ms ease-in-out;
+    position: absolute;
 }
 
 #option-container::-webkit-scrollbar {

--- a/dist/html/options.html
+++ b/dist/html/options.html
@@ -66,6 +66,16 @@
                 Enable the footer in the credential list dropdown
                 <input id="enableDropdownFooter" type="checkbox"/>
             </label>
+            <div class="separator"></div>
+            <label>
+                Selected color in the credential list dropdown
+                <span>
+                    <input id="dropdownSelectedItemColorStart" type="color"
+                           title="The starting color of the background gradient"/>
+                    <input id="dropdownSelectedItemColorEnd" type="color"
+                           title="The ending color of the background gradient"/>
+                </span>
+            </label>
         </div>
         <h2>Shortcuts</h2>
         <div class="group-container">

--- a/dist/html/options.html
+++ b/dist/html/options.html
@@ -76,6 +76,34 @@
                            title="The ending color of the background gradient"/>
                 </span>
             </label>
+            <div class="separator"></div>
+            <label>
+                Border width of the credential list dropdown
+                <span class="range-input">
+                    <span class="value-bubble-container">
+                        <span class="value-bubble"></span>
+                    </span>
+                    <input id="dropdownBorderWidth" type="range" min="0" max="20"/>
+                    <span class="labels">
+                        <span>Smallest</span>
+                        <span>Largest</span>
+                    </span>
+                </span>
+            </label>
+            <div class="separator"></div>
+            <label>
+                Shadow width of the credential list dropdown
+                <span class="range-input">
+                    <span class="value-bubble-container">
+                        <span class="value-bubble">0</span>
+                    </span>
+                    <input id="dropdownShadowWidth" type="range" min="0" max="20"/>
+                    <span class="labels">
+                        <span>Smallest</span>
+                        <span>Largest</span>
+                    </span>
+                </span>
+            </label>
         </div>
         <h2>Shortcuts</h2>
         <div class="group-container">

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -2,6 +2,10 @@
 export interface ITheme {
     /** Show a footer in the credential dropdown list? */
     enableDropdownFooter: boolean;
+    /** The start of the background color gradient of the selected item in the credential dropdown list */
+    dropdownSelectedItemColorStart: string;
+    /** The end of the background color gradient of the selected item in the credential dropdown list */
+    dropdownSelectedItemColorEnd: string;
 }
 
 export interface ISettings
@@ -41,6 +45,8 @@ export const defaultSettings: ISettings =
     searchForInputsOnUpdate: true,
     theme: {
         enableDropdownFooter: true,
+        dropdownSelectedItemColorStart: '#f0f3fb',
+        dropdownSelectedItemColorEnd: '#bac7ec',
     }
 }
 

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -6,6 +6,10 @@ export interface ITheme {
     dropdownSelectedItemColorStart: string;
     /** The end of the background color gradient of the selected item in the credential dropdown list */
     dropdownSelectedItemColorEnd: string;
+    /** The width of the border of the credential dropdown list dropdown */
+    dropdownBorderWidth: number
+    /** The width of the shadow of the credential dropdown list dropdown */
+    dropdownShadowWidth: number
 }
 
 export interface ISettings
@@ -47,6 +51,8 @@ export const defaultSettings: ISettings =
         enableDropdownFooter: true,
         dropdownSelectedItemColorStart: '#f0f3fb',
         dropdownSelectedItemColorEnd: '#bac7ec',
+        dropdownBorderWidth: 1,
+        dropdownShadowWidth: 0,
     }
 }
 

--- a/src/classes/FieldSet.ts
+++ b/src/classes/FieldSet.ts
@@ -203,7 +203,7 @@ export default class FieldSet
         const theme = this._pageControl.settings.theme;
         // Create the dropdown
         this._dropdown = $('<div>').addClass(styles.dropdown).css({
-            left: `${targetOffset && targetOffset.left}px`,
+            left: `${(targetOffset ? targetOffset.left : 0) - 2}px`,
             top: `${targetOffset && targetOffset.top + (target.outerHeight() || 10)}px`,
             width: `${target.outerWidth()}px`
         });

--- a/src/classes/FieldSet.ts
+++ b/src/classes/FieldSet.ts
@@ -71,7 +71,7 @@ export default class FieldSet
                 else
                     this._controlField.removeClass(FieldSet.allIconStyles).addClass(styles.orange);
             }
-            
+
             if(this._dropdown) // Is the dropdown open?
                 this._generateDropdownContent(this._dropdown.find(`.${styles.content}`));
 
@@ -146,7 +146,7 @@ export default class FieldSet
         if(this._oldUsernameValue !== newValue) // The entered value changed?
         {
             this._oldUsernameValue = newValue;
-            
+
             if(this._pageControl.settings.autoComplete) // Is autocomplete enabled?
             {
                 if(this._dropdown === undefined) // The dropdown is not there
@@ -200,20 +200,23 @@ export default class FieldSet
         }
 
         const targetOffset = target.offset();
-
+        const theme = this._pageControl.settings.theme;
         // Create the dropdown
         this._dropdown = $('<div>').addClass(styles.dropdown).css({
-            left: `${targetOffset && targetOffset.left}px`, 
-            top: `${targetOffset && targetOffset.top + (target.outerHeight() || 10)}px`, 
+            left: `${targetOffset && targetOffset.left}px`,
+            top: `${targetOffset && targetOffset.top + (target.outerHeight() || 10)}px`,
             width: `${target.outerWidth()}px`
         });
+        this._dropdown.get(0).style.setProperty(
+            '--dropdown-select-background-start', theme.dropdownSelectedItemColorStart);
+        this._dropdown.get(0).style.setProperty('--dropdown-select-background-end', theme.dropdownSelectedItemColorEnd);
 
         // Generate the content
         const content = $('<div>').addClass(styles.content);
         this._generateDropdownContent(content);
         this._dropdown.append(content);
-        
-        if (this._pageControl.settings.theme.enableDropdownFooter) {
+
+        if (theme.enableDropdownFooter) {
             // Create the footer and add it to the dropdown
             // noinspection HtmlRequiredAltAttribute,RequiredAttributes
             const footerItems: (JQuery | string)[] = [
@@ -267,7 +270,7 @@ export default class FieldSet
             else // No filter
                 credentials = this._pageControl.credentials;
         }
-        
+
         if(credentials.length)
         {
             const items: JQuery[] = [];
@@ -313,7 +316,7 @@ export default class FieldSet
     {
         if(this._dropdown === undefined) // The dropdown is not there
             this._openDropdown(this._controlField); // Try opening the dropdown
-        
+
         if(this._credentialItems && this._credentialItems.length) // There is something available?
         {
             if(this._selectedCredentialIndex !== undefined) // There's something selected?
@@ -340,7 +343,7 @@ export default class FieldSet
     private _enterSelection()
     {
         if(!this._dropdown) return; // We don't want to do this when the dropdown isn't open
-        
+
         if(this._selectedCredential)
         {
             this._inputCredential(this._selectedCredential);

--- a/src/classes/FieldSet.ts
+++ b/src/classes/FieldSet.ts
@@ -203,13 +203,18 @@ export default class FieldSet
         const theme = this._pageControl.settings.theme;
         // Create the dropdown
         this._dropdown = $('<div>').addClass(styles.dropdown).css({
-            left: `${(targetOffset ? targetOffset.left : 0) - 2}px`,
+            left: `${(targetOffset ? targetOffset.left : 0) - Math.max(theme.dropdownShadowWidth, 2)}px`,
             top: `${targetOffset && targetOffset.top + (target.outerHeight() || 10)}px`,
-            width: `${target.outerWidth()}px`
+            width: `${target.outerWidth()}px`,
+            'margin-bottom': `${Math.max(theme.dropdownShadowWidth, 2)}px`,
+            'margin-right': `${Math.max(theme.dropdownShadowWidth, 2)}px`,
+            'margin-left': `${Math.max(theme.dropdownShadowWidth, 2)}px`,
+            'border-width': `${theme.dropdownBorderWidth}px`,
+            'box-shadow': `0 ${theme.dropdownShadowWidth}px ${theme.dropdownShadowWidth}px 0 rgba(0,0,0,0.2)`,
         });
-        this._dropdown.get(0).style.setProperty(
-            '--dropdown-select-background-start', theme.dropdownSelectedItemColorStart);
-        this._dropdown.get(0).style.setProperty('--dropdown-select-background-end', theme.dropdownSelectedItemColorEnd);
+        let style = this._dropdown.get(0).style;
+        style.setProperty('--dropdown-select-background-start', theme.dropdownSelectedItemColorStart);
+        style.setProperty('--dropdown-select-background-end', theme.dropdownSelectedItemColorEnd);
 
         // Generate the content
         const content = $('<div>').addClass(styles.content);

--- a/src/options.ts
+++ b/src/options.ts
@@ -63,6 +63,8 @@ function fillSettings()
         $('#keePassHost').val(settings.keePassHost);
         $('#keePassPort').val(settings.keePassPort);
         $('#enableDropdownFooter').prop('checked', settings.theme.enableDropdownFooter);
+        $('#dropdownSelectedItemColorStart').val(settings.theme.dropdownSelectedItemColorStart);
+        $('#dropdownSelectedItemColorEnd').val(settings.theme.dropdownSelectedItemColorEnd);
     });
 }
 
@@ -83,6 +85,8 @@ function doSave()
         keePassPort: parseInt($('#keePassPort').val() as any),
         theme: {
             enableDropdownFooter: $('#enableDropdownFooter').prop('checked'),
+            dropdownSelectedItemColorStart: $('#dropdownSelectedItemColorStart').val() as string,
+            dropdownSelectedItemColorEnd: $('#dropdownSelectedItemColorEnd').val() as string,
         },
     }).then(() => {
         const saveStatus = $('#saveStatus');

--- a/src/options.ts
+++ b/src/options.ts
@@ -28,7 +28,51 @@ $(()=>{
     else
         $('#cancel').on('click', closeOptionDialog);
     $('#openShortcuts').on('click', openShortcuts);
+    const rangeInputs = $('.range-input');
+    rangeInputs.on('mouseover', (event) => {
+        let valueBubble = event.delegateTarget.querySelector<HTMLElement>('.value-bubble');
+        if (valueBubble) {
+            valueBubble.style.visibility = 'visible';
+        }
+    });
+    rangeInputs.on('mouseout', (event) => {
+        let valueBubble = event.delegateTarget.querySelector<HTMLElement>('.value-bubble');
+        if (valueBubble) {
+            valueBubble.style.visibility = 'hidden';
+        }
+    });
+    rangeInputs.on('input', (event) => {
+        console.log('On Value')
+        onRangeValueChange(event.delegateTarget);
+    });
+    setTimeout(() => {
+        rangeInputs.each((_index, input) => onRangeValueChange(input));
+    }, 100);
 });
+
+/**
+ * Handle the value cahnge of a range input.
+ *
+ * @param rangeInput The range input element that changed.
+ */
+function onRangeValueChange(rangeInput: HTMLElement) {
+    const input = rangeInput.querySelector<HTMLInputElement>('input');
+    if (!input) {
+        return;
+    }
+    const value = parseInt(input.value);
+    const percent = value / parseInt(input.max);
+    input.style.setProperty('--percent', `${percent * 100}%`);
+    let valueBubble = rangeInput.querySelector<HTMLElement>('.value-bubble');
+    if (valueBubble) {
+        valueBubble.textContent = `${value}`;
+        console.log(`parent: ${input.offsetWidth}, bubble: ${valueBubble.offsetWidth}`);
+        const knobSize = 10;
+        const padding = 16;
+        valueBubble.style.marginLeft = `${padding + knobSize / 2 + (input.offsetWidth - (
+            padding * 2 + knobSize)) * (percent) - (valueBubble.offsetWidth / 2)}px`;
+    }
+}
 
 function associate()
 {
@@ -65,6 +109,8 @@ function fillSettings()
         $('#enableDropdownFooter').prop('checked', settings.theme.enableDropdownFooter);
         $('#dropdownSelectedItemColorStart').val(settings.theme.dropdownSelectedItemColorStart);
         $('#dropdownSelectedItemColorEnd').val(settings.theme.dropdownSelectedItemColorEnd);
+        $('#dropdownBorderWidth').val(settings.theme.dropdownBorderWidth);
+        $('#dropdownShadowWidth').val(settings.theme.dropdownShadowWidth);
     });
 }
 
@@ -87,6 +133,8 @@ function doSave()
             enableDropdownFooter: $('#enableDropdownFooter').prop('checked'),
             dropdownSelectedItemColorStart: $('#dropdownSelectedItemColorStart').val() as string,
             dropdownSelectedItemColorEnd: $('#dropdownSelectedItemColorEnd').val() as string,
+            dropdownBorderWidth: $('#dropdownBorderWidth').val() as number,
+            dropdownShadowWidth: $('#dropdownShadowWidth').val() as number,
         },
     }).then(() => {
         const saveStatus = $('#saveStatus');

--- a/src/scss/content.scss
+++ b/src/scss/content.scss
@@ -27,6 +27,7 @@ $lighterDarkPurple: rgba(82, 115, 208, 0.4);
     position: absolute;
     border: 1px solid grey;
     border-radius: 4px;
+    margin: 2px;
     background-color: white;
     min-width: 225px;
     z-index: 999999;
@@ -58,9 +59,18 @@ $lighterDarkPurple: rgba(82, 115, 208, 0.4);
             }
         }
 
+        .item:first-child {
+            -webkit-border-radius: 4px 4px 0 0;
+            -moz-border-radius: 4px 4px 0 0;
+        }
+
+        .item:last-child {
+            border-bottom: 0;
+            -webkit-border-radius: 0 0 4px 4px;
+            -moz-border-radius: 0 0 4px 4px;
+        }
+
         .item.selected, .item:hover {
-            -webkit-border-radius: 4px;
-            -moz-border-radius: 4px;
             background-image: linear-gradient(
                             to right, var(--dropdown-select-background-start), var(--dropdown-select-background-end));
         }

--- a/src/scss/content.scss
+++ b/src/scss/content.scss
@@ -29,6 +29,8 @@ $lighterDarkPurple: rgba(82, 115, 208, 0.4);
     background-color: white;
     min-width: 225px;
     z-index: 999999;
+    --dropdown-select-background-start: $lighterLightPurple;
+    --dropdown-select-background-end: $lighterDarkPurple;
 
     .content {
         font-size: 14px;
@@ -56,7 +58,8 @@ $lighterDarkPurple: rgba(82, 115, 208, 0.4);
         }
 
         .item.selected, .item:hover {
-            background-image: linear-gradient(to right, $lighterLightPurple, $lighterDarkPurple);
+            background-image: linear-gradient(
+                            to right, var(--dropdown-select-background-start), var(--dropdown-select-background-end));
         }
     }
 
@@ -70,7 +73,7 @@ $lighterDarkPurple: rgba(82, 115, 208, 0.4);
         padding: 3px;
         font-weight: bold;
         color: $lightPurple;
-        text-shadow: 0px 0px 2px black;
+        text-shadow: 0 0 2px black;
         box-sizing: border-box;
         font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
 

--- a/src/scss/content.scss
+++ b/src/scss/content.scss
@@ -26,6 +26,7 @@ $lighterDarkPurple: rgba(82, 115, 208, 0.4);
 .dropdown {
     position: absolute;
     border: 1px solid grey;
+    border-radius: 4px;
     background-color: white;
     min-width: 225px;
     z-index: 999999;
@@ -58,6 +59,8 @@ $lighterDarkPurple: rgba(82, 115, 208, 0.4);
         }
 
         .item.selected, .item:hover {
+            -webkit-border-radius: 4px;
+            -moz-border-radius: 4px;
             background-image: linear-gradient(
                             to right, var(--dropdown-select-background-start), var(--dropdown-select-background-end));
         }


### PR DESCRIPTION
This adds three new options to customize the look&feel of the credentials dropdown. That dropdown is the main way for the user of interacting with the credential, and this gives the users the ability to customize the dropdown to their linking.

![The three new theming options](https://user-images.githubusercontent.com/6966049/114796324-f703b980-9d90-11eb-9121-975b1b71f87c.png)

The three new options are:
* <details>
  <summary>The color of the selected item in the credentials list.</summary>

  Because we use a gradient here, the user can choose two colors: The start of the gradient and the end. A tooltip explains which one is which:
  ![Tooltip for the starting color](https://user-images.githubusercontent.com/6966049/114796809-194a0700-9d92-11eb-931b-6d54143c8c3f.png)
  ![Tooltip for the ending color](https://user-images.githubusercontent.com/6966049/114796842-2b2baa00-9d92-11eb-881f-1ff9f0fd79eb.png)
  We use the builtin color picker provided by Chrome and Edge, which is pretty awesome:
  ![Color picker](https://user-images.githubusercontent.com/6966049/114797089-aee59680-9d92-11eb-8f78-52e1b7bb466c.png)


  </details>
* <details>
  <summary>The border width of the credentials dropdown</summary>

  | Setting                    | Dropdown               |
  | --------------------- | --------------------- |
  | Smallest (0)             | ![Credentials dropdown with no (zero width) border](https://user-images.githubusercontent.com/6966049/114798125-ee14e700-9d94-11eb-8b33-77164ff8a0d6.png) |
  | Current/Default (1) | ![Credentials dropdown with default border width](https://user-images.githubusercontent.com/6966049/114797973-9aa29900-9d94-11eb-927d-5ae69a70f9b6.png)  | 
  | Largest (20)             | ![Credentials dropdown with maximum border width](https://user-images.githubusercontent.com/6966049/114798232-2ddbce80-9d95-11eb-8b97-15f722504d28.png) |
  
  I don't really think anyone is going to configure a width of 20, but you never know.
  
  The design of the number selectors is pretty much copied directly from the Crome settings. A bubble with the current value appears, if the mouse is over the slider:
  ![Value bubble above the slider](https://user-images.githubusercontent.com/6966049/114797447-7abea580-9d93-11eb-8fc1-60f58bc8a881.png)

  </details>
* <details>
  <summary>The width of the shadow of the credentials dropdown.</summary>

  This allows the user to configure a shadow for the dropdown, making it visually float above the website. It is disabled by default, to preserve the status quo, but maybe we want to enable this by default? In my opinion the dropdown should have some shadow by default.

  | Setting                                   | Dropdown               |
  | ------------------------------- | --------------------- |
  | Smallest/Current/Default (0) | ![Credentials dropdown without a shadow](https://user-images.githubusercontent.com/6966049/114799228-6e3c4c00-9d97-11eb-82b8-ea6ef0d9aeaa.png) |
  | Largest (20)                            | ![Credentials dropdown with largest shadow width](https://user-images.githubusercontent.com/6966049/114799328-ae9bca00-9d97-11eb-899d-5745907e6e32.png) | 
  </details>

This pull request also makes the corners of the credentials dropdown slightly rounded, to make it look more like the Chrome autofill dropdown and because I personally believe it looks better.

<details>
  <summary>Comparison</summary>

  | Before | After |
  | ------- | ------ |
  | ![Credentials dropdown without rounded corners](https://user-images.githubusercontent.com/6966049/114800476-17844180-9d9a-11eb-95bf-31cf9e9dd217.png) | ![Credentials dropdown with slightly rounded corners](https://user-images.githubusercontent.com/6966049/114800637-5c0fdd00-9d9a-11eb-8f81-d480e081410a.png) |
</details>

And because GitHub doesn't show the diff again because of the line endings, here are the actual changes in `content.scss`:
<details>
  <summary>content.scss</summary>

  ![Changes in content.scss](https://user-images.githubusercontent.com/6966049/114799990-274f5600-9d99-11eb-8394-7d2d074ca109.png)
</details>