### PR TITLE
Improve disabling of autocomplete and autofill

### DIFF
--- a/src/classes/FieldSet.ts
+++ b/src/classes/FieldSet.ts
@@ -36,7 +36,7 @@ export default class FieldSet
         this._controlField = this.usernameField || this.passwordField;
 
         this._controlFieldTitle = this._controlField.attr('title') || '';
-        this._controlField.attr('autocomplete', 'off');
+        this._controlField.attr('autocomplete', 'chrome-off');
 
         this._controlField.on('mousemove', this._onMouseMove.bind(this)).on('mousedown', this._onMouseDown.bind(this)).on('mouseleave', this._activateIcon.bind(this, true)).on('focusin', this._onFocus.bind(this)).on('focusout', this._onFocusLost.bind(this));
         this._controlField.on('click', this._onClick.bind(this)).on('keydown', this._onKeyPress.bind(this)).on('keyup', this._onKeyUp.bind(this));

--- a/src/classes/FieldSet.ts
+++ b/src/classes/FieldSet.ts
@@ -36,7 +36,10 @@ export default class FieldSet
         this._controlField = this.usernameField || this.passwordField;
 
         this._controlFieldTitle = this._controlField.attr('title') || '';
-        this._controlField.attr('autocomplete', 'chrome-off');
+        const inputType = this._controlField.attr('type');
+        const offValue = inputType === 'email' || inputType === 'tel' || inputType === 'password' ?
+            'chrome-off' : 'off';
+        this._controlField.attr('autocomplete', offValue);
 
         this._controlField.on('mousemove', this._onMouseMove.bind(this)).on('mousedown', this._onMouseDown.bind(this)).on('mouseleave', this._activateIcon.bind(this, true)).on('focusin', this._onFocus.bind(this)).on('focusout', this._onFocusLost.bind(this));
         this._controlField.on('click', this._onClick.bind(this)).on('keydown', this._onKeyPress.bind(this)).on('keyup', this._onKeyUp.bind(this));

--- a/src/classes/FieldSet.ts
+++ b/src/classes/FieldSet.ts
@@ -39,7 +39,8 @@ export default class FieldSet
         const inputType = this._controlField.attr('type');
         // See https://stackoverflow.com/questions/15738259/disabling-chrome-autofill
         const isAutofillField = inputType === 'email' || inputType === 'tel' || inputType === 'password'
-            || this._controlField.attr('name')?.toLowerCase()?.includes('email');
+            || this._controlField.attr('name')?.toLowerCase()?.includes('email')
+            || this._controlField.attr('id')?.toLowerCase()?.includes('email');
         this._controlField.attr('autocomplete', isAutofillField ? 'chrome-off' : 'off');
 
         this._controlField.on('mousemove', this._onMouseMove.bind(this)).on('mousedown', this._onMouseDown.bind(this)).on('mouseleave', this._activateIcon.bind(this, true)).on('focusin', this._onFocus.bind(this)).on('focusout', this._onFocusLost.bind(this));

--- a/src/classes/FieldSet.ts
+++ b/src/classes/FieldSet.ts
@@ -37,9 +37,10 @@ export default class FieldSet
 
         this._controlFieldTitle = this._controlField.attr('title') || '';
         const inputType = this._controlField.attr('type');
-        const offValue = inputType === 'email' || inputType === 'tel' || inputType === 'password' ?
-            'chrome-off' : 'off';
-        this._controlField.attr('autocomplete', offValue);
+        // See https://stackoverflow.com/questions/15738259/disabling-chrome-autofill
+        const isAutofillField = inputType === 'email' || inputType === 'tel' || inputType === 'password'
+            || this._controlField.attr('name')?.toLowerCase()?.includes('email');
+        this._controlField.attr('autocomplete', isAutofillField ? 'chrome-off' : 'off');
 
         this._controlField.on('mousemove', this._onMouseMove.bind(this)).on('mousedown', this._onMouseDown.bind(this)).on('mouseleave', this._activateIcon.bind(this, true)).on('focusin', this._onFocus.bind(this)).on('focusout', this._onFocusLost.bind(this));
         this._controlField.on('click', this._onClick.bind(this)).on('keydown', this._onKeyPress.bind(this)).on('keyup', this._onKeyUp.bind(this));


### PR DESCRIPTION
Improves our automatic ability to disable autocomplete/autofill.

There seem to be two systems which can display dropdowns on top of our dropdown:
* Autocomplete, which suggests words that were previously typed into a field.
* Autofill, which will suggest stored information (e.g. name, address, email...) for fields where it thinks it is appropriate.

`autocomplete="off"` will disable autocomplete, but not autofill. Any unrecognized value (e.g. `autocomplete="chrome-off"`) will disable autofill, but not autocomplete.
There is a [Stack Overflow answer](https://stackoverflow.com/a/57810447) which explains it a bit more in detail.

With this pull request we add some of Chrome' autofill heuristics and disable the autofill in these cases. With this patch I have not got a single suggestion dropdown menu from Chrome for the last three months.