### PR TITLE
Add two options to configure the credential list UI

### DIFF
--- a/dist/html/options.html
+++ b/dist/html/options.html
@@ -104,6 +104,20 @@
                     </span>
                 </span>
             </label>
+            <div class="separator"></div>
+            <label>
+                Padding of the items in the credential list dropdown
+                <span class="range-input">
+                    <span class="value-bubble-container">
+                        <span class="value-bubble">0</span>
+                    </span>
+                    <input id="dropdownItemPadding" type="range" min="0" max="20"/>
+                    <span class="labels">
+                        <span>Smallest</span>
+                        <span>Largest</span>
+                    </span>
+                </span>
+            </label>
         </div>
         <h2>Shortcuts</h2>
         <div class="group-container">

--- a/dist/html/options.html
+++ b/dist/html/options.html
@@ -118,6 +118,11 @@
                     </span>
                 </span>
             </label>
+            <div class="separator"></div>
+            <label>
+                Scrollbar color in the credential list dropdown
+                <input id="dropdownScrollbarColor" type="color" title="The color of the scrollbar"/>
+            </label>
         </div>
         <h2>Shortcuts</h2>
         <div class="group-container">

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -12,6 +12,8 @@ export interface ITheme {
     dropdownShadowWidth: number
     /** The padding of an item in the credential dropdown list dropdown */
     dropdownItemPadding: number
+    /** The color of the scrollbar in the credential dropdown list dropdown */
+    dropdownScrollbarColor: string
 }
 
 export interface ISettings
@@ -56,6 +58,7 @@ export const defaultSettings: ISettings =
         dropdownBorderWidth: 1,
         dropdownShadowWidth: 0,
         dropdownItemPadding: 3,
+        dropdownScrollbarColor: '#5273d0'
     }
 }
 

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -10,6 +10,8 @@ export interface ITheme {
     dropdownBorderWidth: number
     /** The width of the shadow of the credential dropdown list dropdown */
     dropdownShadowWidth: number
+    /** The padding of an item in the credential dropdown list dropdown */
+    dropdownItemPadding: number
 }
 
 export interface ISettings
@@ -53,6 +55,7 @@ export const defaultSettings: ISettings =
         dropdownSelectedItemColorEnd: '#bac7ec',
         dropdownBorderWidth: 1,
         dropdownShadowWidth: 0,
+        dropdownItemPadding: 3,
     }
 }
 

--- a/src/classes/CredentialsDropdown.ts
+++ b/src/classes/CredentialsDropdown.ts
@@ -151,7 +151,8 @@ export default class CredentialsDropdown {
             const items: JQuery[] = [];
             credentials.forEach((credential) => {
                 items.push(
-                    $('<div>').data('credential', credential).addClass(styles.item).attr('tabindex', '0').append(
+                    $('<div>').data('credential', credential).addClass(styles.item).attr('tabindex', '0').css(
+                        {'padding': `${this._pageControl.settings.theme.dropdownItemPadding}px`}).append(
                         $('<div>').addClass(styles.primaryText).text(credential.title)
                     ).append(
                         $('<div>').text(credential.username)

--- a/src/classes/CredentialsDropdown.ts
+++ b/src/classes/CredentialsDropdown.ts
@@ -64,6 +64,7 @@ export default class CredentialsDropdown {
         let style = this._dropdown.get(0).style;
         style.setProperty('--dropdown-select-background-start', theme.dropdownSelectedItemColorStart);
         style.setProperty('--dropdown-select-background-end', theme.dropdownSelectedItemColorEnd);
+        style.setProperty('--scrollbar-color', theme.dropdownScrollbarColor);
 
         // Generate the content
         const content = $('<div>').addClass(styles.content);

--- a/src/options.ts
+++ b/src/options.ts
@@ -111,6 +111,7 @@ function fillSettings()
         $('#dropdownSelectedItemColorEnd').val(settings.theme.dropdownSelectedItemColorEnd);
         $('#dropdownBorderWidth').val(settings.theme.dropdownBorderWidth);
         $('#dropdownShadowWidth').val(settings.theme.dropdownShadowWidth);
+        $('#dropdownItemPadding').val(settings.theme.dropdownItemPadding);
     });
 }
 
@@ -135,6 +136,7 @@ function doSave()
             dropdownSelectedItemColorEnd: $('#dropdownSelectedItemColorEnd').val() as string,
             dropdownBorderWidth: $('#dropdownBorderWidth').val() as number,
             dropdownShadowWidth: $('#dropdownShadowWidth').val() as number,
+            dropdownItemPadding: $('#dropdownItemPadding').val() as number,
         },
     }).then(() => {
         const saveStatus = $('#saveStatus');

--- a/src/options.ts
+++ b/src/options.ts
@@ -51,7 +51,7 @@ $(()=>{
 });
 
 /**
- * Handle the value cahnge of a range input.
+ * Handle the value change of a range input.
  *
  * @param rangeInput The range input element that changed.
  */
@@ -112,6 +112,7 @@ function fillSettings()
         $('#dropdownBorderWidth').val(settings.theme.dropdownBorderWidth);
         $('#dropdownShadowWidth').val(settings.theme.dropdownShadowWidth);
         $('#dropdownItemPadding').val(settings.theme.dropdownItemPadding);
+        $('#dropdownScrollbarColor').val(settings.theme.dropdownScrollbarColor);
     });
 }
 
@@ -137,6 +138,7 @@ function doSave()
             dropdownBorderWidth: $('#dropdownBorderWidth').val() as number,
             dropdownShadowWidth: $('#dropdownShadowWidth').val() as number,
             dropdownItemPadding: $('#dropdownItemPadding').val() as number,
+            dropdownScrollbarColor: $('#dropdownScrollbarColor').val() as string,
         },
     }).then(() => {
         const saveStatus = $('#saveStatus');

--- a/src/scss/content.scss
+++ b/src/scss/content.scss
@@ -33,6 +33,22 @@ $lighterDarkPurple: rgba(82, 115, 208, 0.4);
     z-index: 999999;
     --dropdown-select-background-start: $lighterLightPurple;
     --dropdown-select-background-end: $lighterDarkPurple;
+    --scrollbar-color: $darkPurple;
+
+    ::-webkit-scrollbar {
+        height: 4px;
+        width: 4px;
+    }
+
+    ::-webkit-scrollbar-track {
+        background: #f1f1f1;
+        border-radius: 2px;
+    }
+
+    ::-webkit-scrollbar-thumb {
+        background: var(--scrollbar-color);
+        border-radius: 2px;
+    }
 
     .content {
         font-size: 14px;
@@ -41,6 +57,7 @@ $lighterDarkPurple: rgba(82, 115, 208, 0.4);
         font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
         max-height: 200px;
         overflow-y: auto;
+
 
         .noResults {
             color: grey;


### PR DESCRIPTION
This adds two new options to the settings:

* The ability to configure the padding between the items of the credentials list in the dropdown.
  ![The new settings entry to configure the padding](https://user-images.githubusercontent.com/6966049/132997585-f7198db4-7dcc-4ac8-9b37-927bcdd0776d.png)
  Examples:
   | Setting           | Padding       |
   | --------------- | ------------- |
   | 0 (Minimum)   | ![A credentials dropdown list with a padding of 0](https://user-images.githubusercontent.com/6966049/132998070-60c8eadc-9069-42f8-980d-054b2d3ccfd1.PNG) |
   | 3 (Default)       | ![A credentials dropdown list with a padding of 3](https://user-images.githubusercontent.com/6966049/132998099-70b81b04-694b-4925-a579-8ac9ef890c90.PNG) |
   | 20 (Maximum) | ![A credentials dropdown list with a padding of 20](https://user-images.githubusercontent.com/6966049/132998109-f182bdb8-f9d4-4c23-b853-130ad87c44e7.PNG) |

* The ability to configure the color of the scrollbar for the credentials list.
   ![The new settings entry to configure the scrollbar color](https://user-images.githubusercontent.com/6966049/132998194-c58a61a0-d1af-4d74-8df8-daaccb2978d5.png)
