### PR TITLE
Better handling of invisible username/password fields

### DIFF
--- a/src/classes/CredentialsDropdown.ts
+++ b/src/classes/CredentialsDropdown.ts
@@ -47,6 +47,9 @@ export default class CredentialsDropdown {
             this.close();
         }
         const target = fieldSet.controlField;
+        if (target === undefined) {
+            return;
+        }
         const targetOffset = target.offset();
         const theme = this._pageControl.settings.theme;
         // Create the dropdown

--- a/src/classes/PageControl.ts
+++ b/src/classes/PageControl.ts
@@ -67,31 +67,27 @@ export default class PageControl
     private _createFieldSet(passwordField: HTMLElement)
     {
         let prevField: JQuery<HTMLElement> | undefined;
+        let prevVisibleField: JQuery<HTMLElement> | undefined;
         let $passwordField = $(passwordField);
-        let controlField: JQuery<HTMLElement> | undefined;
-
         $('input').each((inputIndex, input) => { // Loop through input fields to find the field before our password field
             const $input = $(input);
-
             const inputType = $input.attr('type') || 'text'; // Get input type, if none default to "text"
-            if (inputType != 'password') // We didn't reach our password field?
-            {
-                if ($input.is(':visible') && (inputType === 'text' || inputType === 'email' || inputType === 'tel'))
-                    prevField = $input; // Is this a possible username field?
-            }
-            else if ($input.is($passwordField))  // Found our password field?
-            {
-                if (prevField) // Is there a previous field? Than this should be our username field
-                    controlField = prevField;
-                else if ($input.is(':visible')) // We didn't find the username field. Check if password field is actually visible
+            if (inputType === 'text' || inputType === 'email' || inputType === 'tel') { // We didn't reach our password field?
+                prevField = $input; // Is this a possible username field?
+                if ($input.is(':visible')) {
+                    prevVisibleField = $input;
+                }
+            } else if (inputType === 'password' && $input.is($(passwordField))) { // Found our password field?
+                let controlField = $input.is(':visible') ? prevVisibleField : prevField;
+                if (!controlField && $input.is(':visible')) {
+                    // We didn't find the username field. Check if password field is actually visible
                     controlField = $passwordField;
-                // Else we didn't find a visible username of password field
+                } // Else we didn't find a visible username of password field
+                if(controlField && !this._fieldSets.has(controlField[0])) // Only create a FieldSet once for every field
+                    this._fieldSets.set(controlField[0], new FieldSet(this, $passwordField, controlField));
                 return false; // Break the each() loop
             }
         });
-        
-        if(controlField && !this._fieldSets.has(controlField[0])) // Only create a FieldSet once for every field
-            this._fieldSets.set(controlField[0], new FieldSet(this, $passwordField, prevField));
     }
 
     private _attachEscapeEvent()


### PR DESCRIPTION
This allows us to keep track of invisible username/password FieldsSets and react to visibility changes.
A common pattern that is used is to hide the password field until a username is entered into the username field.
Another pattern used by [cplusplus.com](https://www.cplusplus.com) is to hide the username and password fields until the login button is clicked.
With this change we also react to visibility changes of the username/password field and move the credential button and dropdown accordingly.

[This zip](https://github.com/RoelVB/ChromeKeePass/files/7150108/hiddenUsernameAndPassword.zip) contains a html page that I used to test this behavior.