### PR TITLE
Improve display of long values in credential list dropdown

### DIFF
--- a/src/scss/content.scss
+++ b/src/scss/content.scss
@@ -72,6 +72,11 @@ $lighterDarkPurple: rgba(82, 115, 208, 0.4);
             cursor: pointer;
             overflow-x: hidden;
 
+            div {
+                text-overflow: ellipsis;
+                overflow: hidden;
+            }
+
             .primaryText {
                 font-weight: bold;
             }


### PR DESCRIPTION
This improves how long values are displayed in the credential list.

Old:
![Long credentials are just cut off](https://user-images.githubusercontent.com/6966049/133239170-57225460-85f0-4262-8cb5-f4311d793c2c.PNG)

New:
![Long credentials are cut off with an elipsis](https://user-images.githubusercontent.com/6966049/133239191-c9e9c115-7286-48a7-b4f3-5eab8d72a8ce.PNG)
