### PR TITLE
Fix dropdown menu style if the body is styled

### DIFF
--- a/src/scss/content.scss
+++ b/src/scss/content.scss
@@ -24,6 +24,7 @@ $lighterDarkPurple: rgba(82, 115, 208, 0.4);
 }
 
 .dropdown {
+    all: revert;
     position: absolute;
     border: 1px solid grey;
     border-radius: 4px;
@@ -31,6 +32,8 @@ $lighterDarkPurple: rgba(82, 115, 208, 0.4);
     background-color: white;
     min-width: 225px;
     z-index: 999999;
+    text-align: start;
+    line-height: normal;
     --dropdown-select-background-start: $lighterLightPurple;
     --dropdown-select-background-end: $lighterDarkPurple;
     --scrollbar-color: $darkPurple;


### PR DESCRIPTION
We were implicitly inheriting some style from the body when we were attaching the dropdown menu.
This resulted for example in a changed text alignment on the Nextcloud login page, because we were implicitly relying on the default value for `text-align`.
Before:
![The text is centered](https://user-images.githubusercontent.com/6966049/133468323-d8af7af8-e96b-40fd-b18b-b509e50fcb0b.PNG)

After:
![The text is left alligned](https://user-images.githubusercontent.com/6966049/133468338-12c5fea8-a553-4130-aca8-5579e856fbfa.PNG)

This fixes this and all other issues like this by resetting all css attributes before applying our style.