### PR TITLE
Improve credential dropdown positioning

### DIFF
--- a/src/classes/CredentialsDropdown.ts
+++ b/src/classes/CredentialsDropdown.ts
@@ -52,11 +52,16 @@ export default class CredentialsDropdown {
         }
         const targetOffset = target.offset();
         const theme = this._pageControl.settings.theme;
+        const targetWidth = target.outerWidth() || 225;
+        let leftOffset = 0;
+        if (targetWidth < 225) { // min-width
+            leftOffset = (225 - targetWidth) / 2.0;
+        }
         // Create the dropdown
         this._dropdown = $('<div>').addClass(styles.dropdown).css({
-            left: `${(targetOffset ? targetOffset.left : 0) - Math.max(theme.dropdownShadowWidth, 2)}px`,
+            left: `${(targetOffset ? targetOffset.left : 0) - Math.max(theme.dropdownShadowWidth, 2) - leftOffset}px`,
             top: `${targetOffset && targetOffset.top + (target.outerHeight() || 10)}px`,
-            width: `${target.outerWidth()}px`,
+            width: `${targetWidth}px`,
             'margin-bottom': `${Math.max(theme.dropdownShadowWidth, 2)}px`,
             'margin-right': `${Math.max(theme.dropdownShadowWidth, 2)}px`,
             'margin-left': `${Math.max(theme.dropdownShadowWidth, 2)}px`,

--- a/src/classes/CredentialsDropdown.ts
+++ b/src/classes/CredentialsDropdown.ts
@@ -50,6 +50,7 @@ export default class CredentialsDropdown {
         if (target === undefined) {
             return;
         }
+        const documentBody = $(document.body);
         const targetOffset = target.offset();
         const theme = this._pageControl.settings.theme;
         const minWidth = 225;
@@ -57,17 +58,22 @@ export default class CredentialsDropdown {
         let left = (targetOffset ? targetOffset.left : 0) - Math.max(theme.dropdownShadowWidth, 2);
         if (targetWidth < minWidth) {
             left -= (minWidth - targetWidth) / 2.0;
-            const screenWidth = $(document.body).outerWidth() || Number.MAX_VALUE;
+            const screenWidth = documentBody.outerWidth() || Number.MAX_VALUE;
             if (left < 0) {
                 left = -Math.max(theme.dropdownShadowWidth, 2);
             } else if (left + minWidth > screenWidth) {
                 left = screenWidth - minWidth - Math.max(theme.dropdownShadowWidth, 2);
             }
         }
+        let top = targetOffset && targetOffset.top + (target.outerHeight() || 10) || 0;
+        if (documentBody.children().first().offsetParent().get(0) === document.body) {
+            top -= parseFloat(documentBody.css('marginTop')) + parseFloat(documentBody.css('borderTopWidth'));
+            left -= parseFloat(documentBody.css('marginLeft')) + parseFloat(documentBody.css('borderLeftWidth'));
+        }
         // Create the dropdown
         this._dropdown = $('<div>').addClass(styles.dropdown).css({
             left: `${left}px`,
-            top: `${targetOffset && targetOffset.top + (target.outerHeight() || 10)}px`,
+            top: `${top}px`,
             width: `${targetWidth}px`,
             'margin-bottom': `${Math.max(theme.dropdownShadowWidth, 2)}px`,
             'margin-right': `${Math.max(theme.dropdownShadowWidth, 2)}px`,

--- a/src/classes/CredentialsDropdown.ts
+++ b/src/classes/CredentialsDropdown.ts
@@ -153,27 +153,27 @@ export default class CredentialsDropdown {
         }
         const documentBody = $(document.body);
         const bodyIsOffsetParent = this._dropdown.offsetParent().get(0) === document.body;
-        const bodyWidth = documentBody.outerWidth(bodyIsOffsetParent) || window.innerWidth;
-        const bodyHeight = documentBody.outerHeight(bodyIsOffsetParent) || window.innerHeight;
+        const bodyWidth = Math.max(documentBody.outerWidth(bodyIsOffsetParent) || 0, window.innerWidth);
+        const bodyHeight = Math.max(documentBody.outerHeight(bodyIsOffsetParent) || 0, window.innerHeight);
         const targetOffset = target.offset();
         const theme = this._pageControl.settings.theme;
         const minWidth = 225;
         const targetWidth = target.outerWidth() || minWidth;
-        let left = (targetOffset ? targetOffset.left : 0) - Math.max(theme.dropdownShadowWidth, 2);
+        let left = (targetOffset?.left || 0) - Math.max(theme.dropdownShadowWidth, 2);
         if (targetWidth < minWidth) {
             left -= (minWidth - targetWidth) / 2.0;
-            if (left < 0) {
-                left = -Math.max(theme.dropdownShadowWidth, 2);
-            } else if (left + minWidth > bodyWidth) {
-                left = bodyWidth - minWidth - Math.max(theme.dropdownShadowWidth, 2);
-            }
         }
-        let top = targetOffset && targetOffset.top + (target.outerHeight() || 10) || 0;
+        if (left < 0) {
+            left = -Math.max(theme.dropdownShadowWidth, 2);
+        } else if (left + minWidth > bodyWidth) {
+            left = bodyWidth - minWidth - Math.max(theme.dropdownShadowWidth, 2);
+        }
+        let top = (targetOffset?.top || 0) + (target.outerHeight() || 10);
         const dropdownHeight = this._dropdown.outerHeight(true) || 0;
         if (top + dropdownHeight > bodyHeight) {
             const offset = dropdownHeight + (target.outerHeight() || 0);
             if (bodyHeight - top >= top || top - offset < 0) {
-                top = window.innerHeight - dropdownHeight;
+                top = bodyHeight - dropdownHeight;
             } else {
                 top -= offset;
             }

--- a/src/classes/CredentialsDropdown.ts
+++ b/src/classes/CredentialsDropdown.ts
@@ -152,6 +152,8 @@ export default class CredentialsDropdown {
             return;
         }
         const documentBody = $(document.body);
+        const bodyIsOffsetParent = this._dropdown.offsetParent().get(0) === document.body;
+        const bodyWidth = documentBody.outerWidth(bodyIsOffsetParent) || window.innerWidth;
         const targetOffset = target.offset();
         const theme = this._pageControl.settings.theme;
         const minWidth = 225;
@@ -161,8 +163,8 @@ export default class CredentialsDropdown {
             left -= (minWidth - targetWidth) / 2.0;
             if (left < 0) {
                 left = -Math.max(theme.dropdownShadowWidth, 2);
-            } else if (left + minWidth > screen.width) {
-                left = screen.width - minWidth - Math.max(theme.dropdownShadowWidth, 2);
+            } else if (left + minWidth > bodyWidth) {
+                left = bodyWidth - minWidth - Math.max(theme.dropdownShadowWidth, 2);
             }
         }
         let top = targetOffset && targetOffset.top + (target.outerHeight() || 10) || 0;

--- a/src/classes/CredentialsDropdown.ts
+++ b/src/classes/CredentialsDropdown.ts
@@ -163,17 +163,17 @@ export default class CredentialsDropdown {
         if (targetWidth < minWidth) {
             left -= (minWidth - targetWidth) / 2.0;
         }
-        if (left < 0) {
-            left = -Math.max(theme.dropdownShadowWidth, 2);
-        } else if (left + minWidth > bodyWidth) {
+        if (left < scrollX) {
+            left = scrollX - Math.max(theme.dropdownShadowWidth, 2);
+        } else if (left + scrollX + minWidth > bodyWidth) {
             left = bodyWidth - minWidth - Math.max(theme.dropdownShadowWidth, 2);
         }
         let top = (targetOffset?.top || 0) + (target.outerHeight() || 10);
         const dropdownHeight = this._dropdown.outerHeight(true) || 0;
-        if (top + dropdownHeight > bodyHeight) {
+        if (top - scrollY + dropdownHeight > bodyHeight) {
             const offset = dropdownHeight + (target.outerHeight() || 0);
-            if (bodyHeight - top >= top || top - offset < 0) {
-                top = bodyHeight - dropdownHeight;
+            if (bodyHeight - top >= top || top - offset < scrollY) {
+                top = scrollY + bodyHeight - dropdownHeight;
             } else {
                 top -= offset;
             }

--- a/src/classes/CredentialsDropdown.ts
+++ b/src/classes/CredentialsDropdown.ts
@@ -154,6 +154,7 @@ export default class CredentialsDropdown {
         const documentBody = $(document.body);
         const bodyIsOffsetParent = this._dropdown.offsetParent().get(0) === document.body;
         const bodyWidth = documentBody.outerWidth(bodyIsOffsetParent) || window.innerWidth;
+        const bodyHeight = documentBody.outerHeight(bodyIsOffsetParent) || window.innerHeight;
         const targetOffset = target.offset();
         const theme = this._pageControl.settings.theme;
         const minWidth = 225;
@@ -168,7 +169,16 @@ export default class CredentialsDropdown {
             }
         }
         let top = targetOffset && targetOffset.top + (target.outerHeight() || 10) || 0;
-        if (this._dropdown.offsetParent().get(0) === document.body) {
+        const dropdownHeight = this._dropdown.outerHeight(true) || 0;
+        if (top + dropdownHeight > bodyHeight) {
+            const offset = dropdownHeight + (target.outerHeight() || 0);
+            if (bodyHeight - top >= top || top - offset < 0) {
+                top = window.innerHeight - dropdownHeight;
+            } else {
+                top -= offset;
+            }
+        }
+        if (bodyIsOffsetParent) {
             top -= parseFloat(documentBody.css('marginTop')) + parseFloat(documentBody.css('borderTopWidth'));
             left -= parseFloat(documentBody.css('marginLeft')) + parseFloat(documentBody.css('borderLeftWidth'));
         }

--- a/src/classes/CredentialsDropdown.ts
+++ b/src/classes/CredentialsDropdown.ts
@@ -52,14 +52,21 @@ export default class CredentialsDropdown {
         }
         const targetOffset = target.offset();
         const theme = this._pageControl.settings.theme;
-        const targetWidth = target.outerWidth() || 225;
-        let leftOffset = 0;
-        if (targetWidth < 225) { // min-width
-            leftOffset = (225 - targetWidth) / 2.0;
+        const minWidth = 225;
+        const targetWidth = target.outerWidth() || minWidth;
+        let left = (targetOffset ? targetOffset.left : 0) - Math.max(theme.dropdownShadowWidth, 2);
+        if (targetWidth < minWidth) {
+            left -= (minWidth - targetWidth) / 2.0;
+            const screenWidth = $(document.body).outerWidth() || Number.MAX_VALUE;
+            if (left < 0) {
+                left = -Math.max(theme.dropdownShadowWidth, 2);
+            } else if (left + minWidth > screenWidth) {
+                left = screenWidth - minWidth - Math.max(theme.dropdownShadowWidth, 2);
+            }
         }
         // Create the dropdown
         this._dropdown = $('<div>').addClass(styles.dropdown).css({
-            left: `${(targetOffset ? targetOffset.left : 0) - Math.max(theme.dropdownShadowWidth, 2) - leftOffset}px`,
+            left: `${left}px`,
             top: `${targetOffset && targetOffset.top + (target.outerHeight() || 10)}px`,
             width: `${targetWidth}px`,
             'margin-bottom': `${Math.max(theme.dropdownShadowWidth, 2)}px`,

--- a/src/classes/CredentialsDropdown.ts
+++ b/src/classes/CredentialsDropdown.ts
@@ -85,9 +85,9 @@ export default class CredentialsDropdown {
             const footer = $('<div>').addClass(styles.footer).append(...footerItems);
             this._dropdown.append(footer);
         }
-        this._reposition();
         // Show the dropdown
         $(document.body).append(this._dropdown);
+        this._reposition();
         $(window).on('resize', this._RESIZE_HANDLER);
     }
 
@@ -159,15 +159,14 @@ export default class CredentialsDropdown {
         let left = (targetOffset ? targetOffset.left : 0) - Math.max(theme.dropdownShadowWidth, 2);
         if (targetWidth < minWidth) {
             left -= (minWidth - targetWidth) / 2.0;
-            const screenWidth = documentBody.outerWidth() || Number.MAX_VALUE;
             if (left < 0) {
                 left = -Math.max(theme.dropdownShadowWidth, 2);
-            } else if (left + minWidth > screenWidth) {
-                left = screenWidth - minWidth - Math.max(theme.dropdownShadowWidth, 2);
+            } else if (left + minWidth > screen.width) {
+                left = screen.width - minWidth - Math.max(theme.dropdownShadowWidth, 2);
             }
         }
         let top = targetOffset && targetOffset.top + (target.outerHeight() || 10) || 0;
-        if (documentBody.children().first().offsetParent().get(0) === document.body) {
+        if (this._dropdown.offsetParent().get(0) === document.body) {
             top -= parseFloat(documentBody.css('marginTop')) + parseFloat(documentBody.css('borderTopWidth'));
             left -= parseFloat(documentBody.css('marginLeft')) + parseFloat(documentBody.css('borderLeftWidth'));
         }


### PR DESCRIPTION
This improves how the credential dropdown is positioned if the input element is close to the screen edges, or if the window is very small. [Here](https://github.com/RoelVB/ChromeKeePass/files/7173586/simpleUsernameAndPasswordAtEdge.zip) is a test page in a zip that was used to test the behavior.

The dropdown menu also now reacts to window size changes and repositions itself. Previously, if you would switch from maximized to windowed mode the dropdown would float detached somewhere on the page.

Additionally, if the input is near the bottom of a scrollable page and there is enough space above, the dropdown will be opend above the input, so the user doesn't have to scroll down the page.

Because this requires us to know the dimensions of the dropdown, it is first added at `0, 0`, measured and then repositioned. This is not visible in the browser.