### PR TITLE
Improve the credential icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "@types/chrome": "^0.0.128",
         "@types/jquery": "^3.5.5",
         "@types/sjcl": "^1.0.29",
+        "@types/resize-observer-browser": "^0.1.5",
         "css-loader": "^0.28.11",
         "node-sass": "^5.0.0",
         "sass-loader": "^10.1.1",

--- a/src/classes/CredentialsIcon.ts
+++ b/src/classes/CredentialsIcon.ts
@@ -9,6 +9,8 @@ export default class CredentialsIcon {
     private readonly _credentialsIcon: JQuery;
     /** Control field resize observer. */
     private readonly _resizeObserver: undefined | ResizeObserver = undefined;
+    /** Whether or not the control field was wrapped in an element. */
+    private readonly _isWrapped: boolean = false;
 
     /**
      * Create and attach a new credentials icon to the control field.
@@ -18,10 +20,6 @@ export default class CredentialsIcon {
      */
     constructor(private readonly _pageControl: PageControl,
                 private _controlField: JQuery, onClickCallback: () => void) {
-        _controlField.wrap($('<div>').addClass(styles.textBoxIconContainer).css({
-            width: '100%',
-            height: '100%',
-        }));
         // Create the username icon
         // noinspection HtmlRequiredAltAttribute,RequiredAttributes
         this._credentialsIcon = $('<img>')
@@ -33,6 +31,17 @@ export default class CredentialsIcon {
         this._reposition();
         this.updateStyle();
         _controlField.offsetParent().append(this._credentialsIcon);
+        if (this._credentialsIcon.get(0).offsetParent === null) {
+            // Some html elements don't display an additional child. Create our own offset parent in this case.
+            this._credentialsIcon.remove();
+            _controlField.wrap($('<div>').addClass(styles.textBoxIconContainer).css({
+                width: '100%',
+                height: '100%',
+            }));
+            this._isWrapped = true;
+            this._reposition();
+            _controlField.offsetParent().append(this._credentialsIcon);
+        }
         if (window.ResizeObserver) {
             this._resizeObserver = new ResizeObserver(_ => this._reposition());
             this._resizeObserver.observe(_controlField.get(0))
@@ -59,7 +68,9 @@ export default class CredentialsIcon {
     public remove() {
         this._resizeObserver?.disconnect();
         this._credentialsIcon.remove();
-        this._controlField.unwrap()
+        if (this._isWrapped) {
+            this._controlField.unwrap();
+        }
     }
 
     /** Update the position and size of the icon. */

--- a/src/classes/CredentialsIcon.ts
+++ b/src/classes/CredentialsIcon.ts
@@ -31,7 +31,8 @@ export default class CredentialsIcon {
         this._reposition();
         this.updateStyle();
         _controlField.offsetParent().append(this._credentialsIcon);
-        if (this._credentialsIcon.get(0).offsetParent === null) {
+        const icon = this._credentialsIcon.get(0);
+        if (icon.offsetParent === null && icon.parentElement !== document.documentElement) {
             // Some html elements don't display an additional child. Create our own offset parent in this case.
             this._credentialsIcon.remove();
             _controlField.wrap($('<div>').addClass(styles.textBoxIconContainer).css({

--- a/src/classes/CredentialsIcon.ts
+++ b/src/classes/CredentialsIcon.ts
@@ -7,6 +7,8 @@ import PageControl from "./PageControl";
 export default class CredentialsIcon {
     /** The KeePass icon in the control field. */
     private readonly _credentialsIcon: JQuery;
+    /** Control field resize observer. */
+    private readonly _resizeObserver: undefined | ResizeObserver = undefined;
 
     /**
      * Create and attach a new credentials icon to the control field.
@@ -16,31 +18,25 @@ export default class CredentialsIcon {
      */
     constructor(private readonly _pageControl: PageControl,
                 private _controlField: JQuery, onClickCallback: () => void) {
-        const fieldWidth = _controlField.outerWidth() || 48
-        const size = Math.min(fieldWidth, _controlField.outerHeight() || 48);
         _controlField.wrap($('<div>').addClass(styles.textBoxIconContainer).css({
             width: '100%',
             height: '100%',
         }));
-        const position = _controlField.position();
         // Create the username icon
         // noinspection HtmlRequiredAltAttribute,RequiredAttributes
         this._credentialsIcon = $('<img>')
             .attr('alt', 'Open the credentials dropdown').attr('title', 'Open the credentials dropdown')
-            .attr('tabindex', '0').addClass(styles.textBoxIcon).css({
-                height: `${size}px`,
-                width: `${size}px`,
-                left: `${position.left + parseFloat(_controlField.css('margin-left')) + fieldWidth - size}px`,
-                top: `${position.top + parseFloat(_controlField.css('margin-top'))}px`,
-                'min-height': `${size}px`,
-                'min-width': `${size}px`,
-                'border-radius': `${size / 2.0}px`,
-            }).on('click', (event) => {
+            .attr('tabindex', '0').addClass(styles.textBoxIcon).on('click', (event) => {
                 event.preventDefault();
                 onClickCallback()
             });
+        this._reposition();
         this.updateStyle();
         _controlField.offsetParent().append(this._credentialsIcon);
+        if (window.ResizeObserver) {
+            this._resizeObserver = new ResizeObserver(_ => this._reposition());
+            this._resizeObserver.observe(_controlField.get(0))
+        }
     }
 
     /**
@@ -61,7 +57,24 @@ export default class CredentialsIcon {
 
     /** Remove the icon from it's control field. */
     public remove() {
+        this._resizeObserver?.disconnect();
         this._credentialsIcon.remove();
         this._controlField.unwrap()
+    }
+
+    /** Update the position and size of the icon. */
+    private _reposition() {
+        const fieldWidth = this._controlField.outerWidth() || 48
+        const size = Math.min(fieldWidth, this._controlField.outerHeight() || 48);
+        const position = this._controlField.position();
+        this._credentialsIcon.css({
+            height: `${size}px`,
+            width: `${size}px`,
+            left: `${position.left + parseFloat(this._controlField.css('margin-left')) + fieldWidth - size}px`,
+            top: `${position.top + parseFloat(this._controlField.css('margin-top'))}px`,
+            'min-height': `${size}px`,
+            'min-width': `${size}px`,
+            'border-radius': `${size / 2.0}px`,
+        })
     }
 }

--- a/src/classes/CredentialsIcon.ts
+++ b/src/classes/CredentialsIcon.ts
@@ -40,7 +40,7 @@ export default class CredentialsIcon {
                 onClickCallback()
             });
         this.updateStyle();
-        _controlField.after(this._credentialsIcon);
+        _controlField.offsetParent().append(this._credentialsIcon);
     }
 
     /**

--- a/src/classes/CredentialsIcon.ts
+++ b/src/classes/CredentialsIcon.ts
@@ -1,0 +1,67 @@
+import * as $ from 'jquery-slim';
+import * as styles from "../scss/content.scss";
+import PageControl from "./PageControl";
+
+
+/** An icon that is displayed on the control field and can open and close the credentials dropdown. */
+export default class CredentialsIcon {
+    /** The KeePass icon in the control field. */
+    private readonly _credentialsIcon: JQuery;
+
+    /**
+     * Create and attach a new credentials icon to the control field.
+     * @param _pageControl The current page controller.
+     * @param _controlField The input field in which to display the icon.
+     * @param onClickCallback A callback to invoke when the icon was clicked.
+     */
+    constructor(private readonly _pageControl: PageControl,
+                private _controlField: JQuery, onClickCallback: () => void) {
+        const fieldWidth = _controlField.outerWidth() || 48
+        const size = Math.min(fieldWidth, _controlField.outerHeight() || 48);
+        _controlField.wrap($('<div>').addClass(styles.textBoxIconContainer).css({
+            width: '100%',
+            height: '100%',
+        }));
+        const position = _controlField.position();
+        // Create the username icon
+        // noinspection HtmlRequiredAltAttribute,RequiredAttributes
+        this._credentialsIcon = $('<img>')
+            .attr('alt', 'Open the credentials dropdown').attr('title', 'Open the credentials dropdown')
+            .attr('tabindex', '0').addClass(styles.textBoxIcon).css({
+                height: `${size}px`,
+                width: `${size}px`,
+                left: `${position.left + parseFloat(_controlField.css('margin-left')) + fieldWidth - size}px`,
+                top: `${position.top + parseFloat(_controlField.css('margin-top'))}px`,
+                'min-height': `${size}px`,
+                'min-width': `${size}px`,
+                'border-radius': `${size / 2.0}px`,
+            }).on('click', (event) => {
+                event.preventDefault();
+                onClickCallback()
+            });
+        this.updateStyle();
+        _controlField.after(this._credentialsIcon);
+    }
+
+    /**
+     * @return Whether or not the event caused the icon to gain focus.
+     */
+    public hasGainedFocus(event: JQuery.FocusOutEvent): boolean {
+        return event.relatedTarget instanceof HTMLElement && this._credentialsIcon.get(0) === event.relatedTarget;
+    }
+
+    /** Update the style of the username icon to reflect the current availability of credentials. */
+    public updateStyle() {
+        let iconStyle = 'red';
+        if (this._pageControl.credentials) {
+            iconStyle = this._pageControl.credentials.length ? 'green' : 'orange';
+        }
+        this._credentialsIcon.attr('src', chrome.extension.getURL(`images/icon48_${iconStyle}.png`));
+    }
+
+    /** Remove the icon from it's control field. */
+    public remove() {
+        this._credentialsIcon.remove();
+        this._controlField.unwrap()
+    }
+}

--- a/src/scss/content.scss
+++ b/src/scss/content.scss
@@ -4,6 +4,11 @@ $lighterLightPurple: rgba(218, 225, 245, 0.4);
 $darkPurple: rgb(82, 115, 208);
 $lighterDarkPurple: rgba(82, 115, 208, 0.4);
 
+.textBoxIconContainer {
+    display: inline;
+    position: relative;
+}
+
 .textBoxIcon {
     position: absolute;
     cursor: pointer;

--- a/src/scss/content.scss
+++ b/src/scss/content.scss
@@ -4,23 +4,13 @@ $lighterLightPurple: rgba(218, 225, 245, 0.4);
 $darkPurple: rgb(82, 115, 208);
 $lighterDarkPurple: rgba(82, 115, 208, 0.4);
 
-.textboxIcon {
-    background-image: url('chrome-extension://__MSG_@@extension_id__/images/icon48.png') !important;
-    background-repeat: no-repeat !important;
-    background-position: right !important;
-    background-size: auto 100% !important;
-}
-
-.textboxIcon.green {
-    background-image: url('chrome-extension://__MSG_@@extension_id__/images/icon48_green.png') !important;
-}
-
-.textboxIcon.orange {
-    background-image: url('chrome-extension://__MSG_@@extension_id__/images/icon48_orange.png') !important;
-}
-
-.textboxIcon.red {
-    background-image: url('chrome-extension://__MSG_@@extension_id__/images/icon48_red.png') !important;
+.textBoxIcon {
+    position: absolute;
+    cursor: pointer;
+    z-index: 999998;
+    padding: 2px;
+    outline: none;
+    box-sizing: border-box;
 }
 
 .dropdown {

--- a/styleTransform.js
+++ b/styleTransform.js
@@ -1,6 +1,0 @@
-
-module.exports = function(css)
-{
-    // Insert the extension ID into CSS
-    return css.replace(/__MSG_@@extension_id__/g, chrome.runtime.id);
-}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,13 +18,7 @@ module.exports = {
                 exclude: /node_modules/,
                 test: /\.scss$/,
                 use: [
-                    {
-                        loader: 'style-loader',
-                        options: {
-                            convertToAbsoluteUrls: false,
-                            transform: './styleTransform.js',
-                        },
-                    },
+                    'style-loader',
                     {
                         loader: 'typings-for-css-modules-loader',
                         options: {


### PR DESCRIPTION
The current implementation of the credentials icon has a couple of issues:
* <details><summary>The text inside the input can overlap with the icon.</summary>

  The password field on the Amazon login page:
![The password value overlaps with the credentials icon](https://user-images.githubusercontent.com/6966049/133524498-5e4db808-cbca-429e-9ee2-d1cc917b63bf.PNG)
  </details>
* <details><summary>The same applies for the hint text.</summary>

  The username field on the Nextcloud login page:
![The username hint text overlaps with the credentials icon](https://user-images.githubusercontent.com/6966049/133524755-37e20fca-88a9-454d-8917-299bf51186a6.PNG)
  </details>
* <details><summary>Other UI elements can also overlay over the icon.</summary>

  The username field on Apples login page:
![A "Next" button is overlaying over the credentials icon](https://user-images.githubusercontent.com/6966049/133524873-bb175eb6-25df-4b00-8792-c7b882882509.PNG)
  </details>
* We are potentially overwriting a background image of the input that the website specified.
* We are potentially restoring the wrong title if the website would change it while we hovered over the credentials icon.

To fix these problems, this pull requests uses a separate `img` element that is positioned above the input field, similar to the dropdown menu.
<details><summary>This fixes the problems described above,</summary>

![The password field value no longer overlaps with the credentials icon](https://user-images.githubusercontent.com/6966049/133525755-40942d2e-3e9c-4396-aa89-3ae4adc7713e.PNG)
![The username field hint text no longer overlaps with the credentials icon](https://user-images.githubusercontent.com/6966049/133525767-91bacb6b-8609-46ab-bd6b-f03dfdda39a9.PNG)
![other UI elements no longer overlaps with the credentials icon](https://user-images.githubusercontent.com/6966049/133525775-2a8cea01-4072-410a-9bf2-18b58a8ccce5.PNG)
</details>
but it requires us to move the credential icon manually, if the input moved.

[This](https://github.com/RoelVB/ChromeKeePass/files/7173812/movingUsernameAndPassword.zip) is a test web page in a zip that can be used to test the behavior of the credentials icon on moving inputs.